### PR TITLE
fix(client): store command request UUID

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -152,6 +152,8 @@ class Client {
 
   void generate_uuid_(pb_byte_t uuid[16]);
 
+  void store_last_request_uuid_(UniversalMessage_Domain domain, const pb_byte_t *uuid, pb_size_t uuid_size);
+
   int generate_public_key_data_();
   int generate_key_id_();
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -524,13 +524,7 @@ int Client::build_universal_message_with_payload(pb_byte_t *payload, size_t payl
   UniversalMessage_RoutableMessage universal_message = UniversalMessage_RoutableMessage_init_default;
   prepare_routable_message_(universal_message, domain);
 
-  if (domain == UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY) {
-    std::copy(universal_message.uuid.bytes, universal_message.uuid.bytes + 16, last_request_uuid_vcsec_.begin());
-    last_request_uuid_vcsec_length_ = universal_message.uuid.size;
-  } else if (domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
-    std::copy(universal_message.uuid.bytes, universal_message.uuid.bytes + 16, last_request_uuid_infotainment_.begin());
-    last_request_uuid_infotainment_length_ = universal_message.uuid.size;
-  }
+  store_last_request_uuid_(domain, universal_message.uuid.bytes, universal_message.uuid.size);
 
   LOG_DEBUG("Building message for domain: %s", domain_to_string(domain));
   auto *session = get_peer(domain);
@@ -649,13 +643,7 @@ int Client::build_session_info_request_message(UniversalMessage_Domain domain, p
   UniversalMessage_RoutableMessage universal_message = UniversalMessage_RoutableMessage_init_default;
   prepare_routable_message_(universal_message, domain);
 
-  if (domain == UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY) {
-    std::copy(universal_message.uuid.bytes, universal_message.uuid.bytes + 16, last_request_uuid_vcsec_.begin());
-    last_request_uuid_vcsec_length_ = universal_message.uuid.size;
-  } else if (domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
-    std::copy(universal_message.uuid.bytes, universal_message.uuid.bytes + 16, last_request_uuid_infotainment_.begin());
-    last_request_uuid_infotainment_length_ = universal_message.uuid.size;
-  }
+  store_last_request_uuid_(domain, universal_message.uuid.bytes, universal_message.uuid.size);
 
   universal_message.which_payload = UniversalMessage_RoutableMessage_session_info_request_tag;
   UniversalMessage_SessionInfoRequest session_info_request = UniversalMessage_SessionInfoRequest_init_default;
@@ -950,6 +938,16 @@ void Client::generate_uuid_(pb_byte_t uuid[16]) {
     for (int i = 0; i < 16; i++) {
       uuid[i] = arc4random() % 256;
     }
+  }
+}
+
+void Client::store_last_request_uuid_(UniversalMessage_Domain domain, const pb_byte_t *uuid, pb_size_t uuid_size) {
+  if (domain == UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY) {
+    std::copy(uuid, uuid + uuid_size, last_request_uuid_vcsec_.begin());
+    last_request_uuid_vcsec_length_ = uuid_size;
+  } else if (domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
+    std::copy(uuid, uuid + uuid_size, last_request_uuid_infotainment_.begin());
+    last_request_uuid_infotainment_length_ = uuid_size;
   }
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -524,6 +524,14 @@ int Client::build_universal_message_with_payload(pb_byte_t *payload, size_t payl
   UniversalMessage_RoutableMessage universal_message = UniversalMessage_RoutableMessage_init_default;
   prepare_routable_message_(universal_message, domain);
 
+  if (domain == UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY) {
+    std::copy(universal_message.uuid.bytes, universal_message.uuid.bytes + 16, last_request_uuid_vcsec_.begin());
+    last_request_uuid_vcsec_length_ = universal_message.uuid.size;
+  } else if (domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
+    std::copy(universal_message.uuid.bytes, universal_message.uuid.bytes + 16, last_request_uuid_infotainment_.begin());
+    last_request_uuid_infotainment_length_ = universal_message.uuid.size;
+  }
+
   LOG_DEBUG("Building message for domain: %s", domain_to_string(domain));
   auto *session = get_peer(domain);
   universal_message.which_payload = UniversalMessage_RoutableMessage_protobuf_message_as_bytes_tag;

--- a/tests/test_client.cpp
+++ b/tests/test_client.cpp
@@ -41,6 +41,31 @@ TEST_F(ClientTest, BuildWhiteListMessage) {
   EXPECT_LE(whitelist_message_length, sizeof(whitelist_message_buffer)) << "Message should fit in buffer";
 }
 
+TEST_F(ClientTest, BuildUniversalMessageUpdatesLastRequestUuid) {
+  pb_byte_t payload[] = {0x01};
+  pb_byte_t buffer[512];
+  size_t length = sizeof(buffer);
+
+  auto result = client_->build_universal_message_with_payload(
+      payload, 1, UniversalMessage_Domain_DOMAIN_INFOTAINMENT, buffer, &length, false);
+  ASSERT_EQ(result, TeslaBLE_Status_E_OK) << "build_universal_message_with_payload should succeed";
+
+  UniversalMessage_RoutableMessage parsed = UniversalMessage_RoutableMessage_init_default;
+  result = client_->parse_universal_message(buffer, length, &parsed);
+  ASSERT_EQ(result, TeslaBLE_Status_E_OK) << "parse_universal_message should succeed";
+
+  pb_byte_t stored_uuid[16] = {};
+  size_t stored_uuid_len = sizeof(stored_uuid);
+  if (client_->get_last_request_uuid(UniversalMessage_Domain_DOMAIN_INFOTAINMENT, stored_uuid, &stored_uuid_len)) {
+    EXPECT_EQ(stored_uuid_len, 16u);
+    EXPECT_EQ(memcmp(parsed.uuid.bytes, stored_uuid, 16), 0)
+        << "get_last_request_uuid must return the UUID from the last built message";
+  } else {
+    FAIL() << "build_universal_message_with_payload must update last_request_uuid "
+              "(was not stored — error-recovery session_info HMAC verification would fail)";
+  }
+}
+
 TEST_F(ClientTest, BuildWhiteListMessageInvalidRole) {
   unsigned char whitelist_message_buffer[VCSEC_ToVCSECMessage_size];
   size_t whitelist_message_length;

--- a/tests/test_client.cpp
+++ b/tests/test_client.cpp
@@ -46,8 +46,8 @@ TEST_F(ClientTest, BuildUniversalMessageUpdatesLastRequestUuid) {
   pb_byte_t buffer[512];
   size_t length = sizeof(buffer);
 
-  auto result = client_->build_universal_message_with_payload(
-      payload, 1, UniversalMessage_Domain_DOMAIN_INFOTAINMENT, buffer, &length, false);
+  auto result = client_->build_universal_message_with_payload(payload, 1, UniversalMessage_Domain_DOMAIN_INFOTAINMENT,
+                                                              buffer, &length, false);
   ASSERT_EQ(result, TeslaBLE_Status_E_OK) << "build_universal_message_with_payload should succeed";
 
   UniversalMessage_RoutableMessage parsed = UniversalMessage_RoutableMessage_init_default;


### PR DESCRIPTION
Store generated UUID in last_request_uuid_* so HMAC verification during session error recovery uses the command's UUID, not a stale one.

Extract duplicated UUID storage into store_last_request_uuid_ helper.