### PR TITLE
fix(peer): use steady_clock for message expiry

### DIFF
--- a/include/peer.h
+++ b/include/peer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <mutex>
 #include <memory>
@@ -166,6 +167,7 @@ class Peer {
   uint32_t counter_ = 0;
   uint32_t time_zero_ = 0;
   uint32_t clock_time_ = 0;  // Last received clock_time (like signer.go setTime)
+  std::chrono::steady_clock::time_point session_start_monotonic_{};
 
   // Cryptographic context
   std::shared_ptr<CryptoContext> crypto_context_;

--- a/include/peer.h
+++ b/include/peer.h
@@ -67,7 +67,6 @@ class Peer {
   void clear_shared_secret();
 
   // Getters
-  uint32_t get_time_zero() const { return time_zero_; }
   uint32_t get_counter() const;
   const pb_byte_t *get_epoch() const { return epoch_.data(); }
   UniversalMessage_Domain get_domain() const { return domain_; }
@@ -80,7 +79,6 @@ class Peer {
   void set_counter(uint32_t counter);
   void increment_counter();
   int set_epoch(const pb_byte_t *epoch);
-  void set_time_zero(uint32_t time_zero) { time_zero_ = time_zero; }
   void set_vin(const std::string &vin) { vin_ = vin; }
 
   // Session operations
@@ -165,7 +163,6 @@ class Peer {
   // Epoch and timing
   std::array<pb_byte_t, EPOCH_SIZE_BYTES> epoch_{};
   uint32_t counter_ = 0;
-  uint32_t time_zero_ = 0;
   uint32_t clock_time_ = 0;  // Last received clock_time (like signer.go setTime)
   std::chrono::steady_clock::time_point session_start_monotonic_{};
 

--- a/src/peer.cpp
+++ b/src/peer.cpp
@@ -80,6 +80,7 @@ void Peer::clear_shared_secret() {
   counter_ = 0;
   clock_time_ = 0;
   time_zero_ = 0;
+  session_start_monotonic_ = std::chrono::steady_clock::time_point{};
 
   response_window_.reset();
 
@@ -116,10 +117,10 @@ int Peer::set_epoch(const pb_byte_t *epoch) {
 uint32_t Peer::get_counter() const { return counter_; }
 
 uint32_t Peer::generate_expires_at(int seconds) const {
-  uint32_t expires_at =
-      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now() + std::chrono::seconds(seconds)) -
-      time_zero_;
-  return expires_at;
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - session_start_monotonic_)
+          .count();
+  return clock_time_ + static_cast<uint32_t>(elapsed) + static_cast<uint32_t>(seconds);
 }
 
 void Peer::generate_nonce(pb_byte_t *nonce) const {
@@ -235,6 +236,7 @@ int Peer::update_session(Signatures_SessionInfo *session_info) {
       return status;
     }
     clock_time_ = session_info->clock_time;
+    session_start_monotonic_ = std::chrono::steady_clock::now();
 
     uint32_t generated_at = std::time(nullptr);
     uint32_t time_zero = generated_at - session_info->clock_time;
@@ -283,6 +285,7 @@ int Peer::force_update_session(Signatures_SessionInfo *session_info) {
 
   set_counter(session_info->counter);
   clock_time_ = session_info->clock_time;
+  session_start_monotonic_ = std::chrono::steady_clock::now();
   uint32_t generated_at = std::time(nullptr);
   uint32_t time_zero = generated_at - session_info->clock_time;
   set_time_zero(time_zero);

--- a/src/peer.cpp
+++ b/src/peer.cpp
@@ -28,7 +28,6 @@
 #include <mbedtls/pk.h>
 #include <mbedtls/sha1.h>
 
-#include <chrono>
 #include <cinttypes>
 #include <cstring>
 
@@ -79,7 +78,6 @@ void Peer::clear_shared_secret() {
 
   counter_ = 0;
   clock_time_ = 0;
-  time_zero_ = 0;
   session_start_monotonic_ = std::chrono::steady_clock::time_point{};
 
   response_window_.reset();
@@ -237,10 +235,6 @@ int Peer::update_session(Signatures_SessionInfo *session_info) {
     }
     clock_time_ = session_info->clock_time;
     session_start_monotonic_ = std::chrono::steady_clock::now();
-
-    uint32_t generated_at = std::time(nullptr);
-    uint32_t time_zero = generated_at - session_info->clock_time;
-    set_time_zero(time_zero);
   } else {
     LOG_DEBUG("Session info not newer - skipping update");
   }
@@ -257,7 +251,7 @@ int Peer::update_session(Signatures_SessionInfo *session_info) {
     }
   }
 
-  LOG_DEBUG("Updated session: counter=%d, clock_time=%d, time_zero=%d", counter_, session_info->clock_time, time_zero_);
+  LOG_DEBUG("Updated session: counter=%d, clock_time=%d", counter_, session_info->clock_time);
 
   // Successful update clears error state and restores session validity
   // This matches Go's UpdateSessionInfo behavior where successful updates restore session
@@ -286,9 +280,6 @@ int Peer::force_update_session(Signatures_SessionInfo *session_info) {
   set_counter(session_info->counter);
   clock_time_ = session_info->clock_time;
   session_start_monotonic_ = std::chrono::steady_clock::now();
-  uint32_t generated_at = std::time(nullptr);
-  uint32_t time_zero = generated_at - session_info->clock_time;
-  set_time_zero(time_zero);
 
   if (session_info->publicKey.size > 0) {
     LOG_DEBUG("Deriving shared secret from session info public key (force update)");
@@ -302,7 +293,7 @@ int Peer::force_update_session(Signatures_SessionInfo *session_info) {
   is_valid_ = true;
   has_shared_secret_ = true;
 
-  LOG_INFO("Force updated session: counter=%u, clock_time=%u, time_zero=%u", counter_, clock_time_, time_zero_);
+  LOG_INFO("Force updated session: counter=%u, clock_time=%u", counter_, clock_time_);
   return TeslaBLE_Status_E_OK;
 }
 

--- a/tests/test_protocol_authentication.cpp
+++ b/tests/test_protocol_authentication.cpp
@@ -121,27 +121,36 @@ TEST_F(ProtocolAuthenticationTest, CounterEdgeCases) {
   }
 }
 
-// Test 4: Time and Expiration Handling
+// Test 4: Time and Expiration Handling — uses monotonic clock in generate_expires_at
 TEST_F(ProtocolAuthenticationTest, TimeAndExpirationHandling) {
+  crypto_context_->load_private_key(reinterpret_cast<const uint8_t *>(TestConstants::CLIENT_PRIVATE_KEY_PEM),
+                                    strlen(TestConstants::CLIENT_PRIVATE_KEY_PEM) + 1);
+
   Peer peer(UniversalMessage_Domain_DOMAIN_INFOTAINMENT, crypto_context_, TestConstants::TEST_VIN);
 
-  // Set a base time
-  peer.set_time_zero(1000);
+  Signatures_SessionInfo session_info = Signatures_SessionInfo_init_default;
+  session_info.counter = 1;
+  session_info.clock_time = 1000;
+  memcpy(session_info.epoch, TestConstants::TEST_EPOCH, 16);
+  memcpy(session_info.publicKey.bytes, TestConstants::EXPECTED_VEHICLE_PUBLIC_KEY, 65);
+  session_info.publicKey.size = 65;
 
-  // Test expiration calculation
-  uint32_t expires_30_sec = peer.generate_expires_at(30);
-  uint32_t expires_60_sec = peer.generate_expires_at(60);
+  auto result = peer.update_session(&session_info);
+  ASSERT_EQ(result, TeslaBLE_Status_E_OK);
 
-  EXPECT_GT(expires_60_sec, expires_30_sec) << "Longer expiration should have higher value";
-  EXPECT_EQ(expires_60_sec - expires_30_sec, 30) << "Time difference should match";
+  // expires_at should be approximately clock_time + seconds
+  // (using monotonic elapsed time since session start, not system wall clock)
+  uint32_t expires_5 = peer.generate_expires_at(5);
+  EXPECT_GE(expires_5, 1005u);
+  EXPECT_LE(expires_5, 1005u + 1u) << "expires_at should be clock_time + elapsed + 5";
 
-  // Test with zero expiration
-  uint32_t expires_zero = peer.generate_expires_at(0);
-  EXPECT_GE(expires_zero, peer.get_time_zero()) << "Zero expiration should be at least current time";
+  uint32_t expires_30 = peer.generate_expires_at(30);
+  EXPECT_GE(expires_30, 1030u);
 
-  // Test with negative expiration (should handle gracefully)
-  uint32_t expires_negative = peer.generate_expires_at(-10);
-  EXPECT_GE(expires_negative, peer.get_time_zero()) << "Negative expiration should be handled gracefully";
+  // 30s should be 25s more than 5s (same monotonic reference frame)
+  uint32_t delta = expires_30 - expires_5;
+  EXPECT_GE(delta, 24u);
+  EXPECT_LE(delta, 25u);
 }
 
 // Test 5: Nonce Generation and Uniqueness


### PR DESCRIPTION
- Replace system_clock with steady_clock in generate_expires_at to eliminate NTP jump / wall-clock drift causing spurious expiry.
- Remove dead time_zero_, get_time_zero(), set_time_zero() and redundant <chrono> include.