### PR TITLE
fix: surface CarServer action errors

### DIFF
--- a/src/tb_logging.cpp
+++ b/src/tb_logging.cpp
@@ -613,6 +613,87 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
   if (charge_state.which_optional_minutes_to_full_charge) {
     LOG_DEBUG("Minutes to Full: %ld", charge_state.optional_minutes_to_full_charge.minutes_to_full_charge);
   }
+
+  if (charge_state.which_optional_minutes_to_charge_limit) {
+    LOG_DEBUG("Minutes to Charge Limit: %ld", charge_state.optional_minutes_to_charge_limit.minutes_to_charge_limit);
+  }
+
+  if (charge_state.which_optional_charger_voltage) {
+    LOG_DEBUG("Charger Voltage: %ld", charge_state.optional_charger_voltage.charger_voltage);
+  }
+
+  if (charge_state.which_optional_charger_pilot_current) {
+    LOG_DEBUG("Charger Pilot Current: %ld", charge_state.optional_charger_pilot_current.charger_pilot_current);
+  }
+
+  if (charge_state.which_optional_charger_actual_current) {
+    LOG_DEBUG("Charger Actual Current: %ld", charge_state.optional_charger_actual_current.charger_actual_current);
+  }
+
+  if (charge_state.which_optional_charge_current_request) {
+    LOG_DEBUG("Charge Current Request: %ld", charge_state.optional_charge_current_request.charge_current_request);
+  }
+
+  if (charge_state.which_optional_charge_current_request_max) {
+    LOG_DEBUG("Charge Current Request Max: %ld",
+              charge_state.optional_charge_current_request_max.charge_current_request_max);
+  }
+
+  if (charge_state.which_optional_user_charge_enable_request) {
+    LOG_DEBUG("User Charge Enable Request: %s",
+              charge_state.optional_user_charge_enable_request.user_charge_enable_request ? "true" : "false");
+  }
+
+  if (charge_state.which_optional_charge_enable_request) {
+    LOG_DEBUG("Charge Enable Request: %s",
+              charge_state.optional_charge_enable_request.charge_enable_request ? "true" : "false");
+  }
+
+  if (charge_state.which_optional_charge_port_door_open) {
+    LOG_DEBUG("Charge Port Door Open: %s",
+              charge_state.optional_charge_port_door_open.charge_port_door_open ? "true" : "false");
+  }
+
+  if (charge_state.which_optional_charge_port_cold_weather_mode) {
+    LOG_DEBUG("Charge Port Cold Weather Mode: %s",
+              charge_state.optional_charge_port_cold_weather_mode.charge_port_cold_weather_mode ? "true" : "false");
+  }
+
+  if (charge_state.which_optional_charge_cable_unlatched) {
+    LOG_DEBUG("Charge Cable Unlatched: %s",
+              charge_state.optional_charge_cable_unlatched.charge_cable_unlatched ? "true" : "false");
+  }
+
+  if (charge_state.which_optional_charger_phases) {
+    LOG_DEBUG("Charger Phases: %ld", charge_state.optional_charger_phases.charger_phases);
+  }
+
+  if (charge_state.which_optional_charge_port_color) {
+    LOG_DEBUG("Charge Port Color: %d", charge_state.optional_charge_port_color.charge_port_color);
+  }
+
+  if (charge_state.which_optional_charge_limit_reason) {
+    LOG_DEBUG("Charge Limit Reason: %d", charge_state.optional_charge_limit_reason.charge_limit_reason);
+  }
+
+  if (charge_state.has_managed_charging_state) {
+    LOG_DEBUG("Managed Charging State present");
+    if (charge_state.managed_charging_state.has_charge_on_solar_state) {
+      LOG_DEBUG("Charge On Solar State: %d", charge_state.managed_charging_state.charge_on_solar_state.which_state);
+    }
+    if (charge_state.managed_charging_state.which_optional_minutes_to_lower_limit) {
+      LOG_DEBUG("Managed Charging Minutes to Lower Limit: %ld",
+                charge_state.managed_charging_state.optional_minutes_to_lower_limit.minutes_to_lower_limit);
+    }
+  }
+
+  if (charge_state.which_optional_outlet_state) {
+    LOG_DEBUG("Outlet State: %d", charge_state.optional_outlet_state.outlet_state);
+  }
+
+  if (charge_state.which_optional_power_feed_state) {
+    LOG_DEBUG("Power Feed State: %d", charge_state.optional_power_feed_state.power_feed_state);
+  }
 }
 
 void log_carserver_response(const char *tag, const CarServer_Response *msg) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -22,6 +22,24 @@
 
 namespace TeslaBLE {
 
+namespace {
+
+std::unique_ptr<CommandError> build_carserver_action_error(const CarServer_ActionStatus &status) {
+  std::string message = "Infotainment action failed";
+  if (status.has_result_reason && status.result_reason.which_reason == CarServer_ResultReason_plain_text_tag) {
+    message += ": ";
+    message += status.result_reason.reason.plain_text;
+  }
+
+  return CommandError::create()
+      .with_message(message)
+      .with_severity(CommandError::Severity::PERMANENT)
+      .with_outcome(CommandError::Outcome::DEFINITELY_FAILED)
+      .build();
+}
+
+}  // namespace
+
 Vehicle::Vehicle(const std::shared_ptr<BleAdapter> &ble, const std::shared_ptr<StorageAdapter> &storage)
     : ble_adapter_(ble),
       storage_adapter_(storage),
@@ -816,7 +834,7 @@ void TeslaBLE::Vehicle::handle_carserver_message_(const UniversalMessage_Routabl
         mark_command_completed_(cmd);
       } else {
         LOG_ERROR("CarServer Action Failed");
-        mark_command_failed_(cmd, CommandError::authentication_failed("Infotainment action"));
+        mark_command_failed_(cmd, build_carserver_action_error(response.actionStatus));
       }
     } else if (response.which_response_msg == CarServer_Response_vehicleData_tag) {
       mark_command_completed_(cmd);

--- a/tests/test_message_parsing.cpp
+++ b/tests/test_message_parsing.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <ranges>
 #include <cstring>
+#include "tb_utils.h"
 #include "test_constants.h"
 
 using namespace TeslaBLE;
@@ -236,4 +237,37 @@ TEST_F(MessageParsingTest, ParsePayloadCarServerResponseEdgeCases) {
                                                       UniversalMessage_MessageFault_E_MESSAGEFAULT_ERROR_NONE, 0,
                                                       &parsed_response);
   EXPECT_NE(result, TeslaBLE_Status_E_OK) << "Parsing with truncated data should fail";
+}
+
+TEST_F(MessageParsingTest, ParsePayloadCarServerResponseChargeLimitReasonOneof) {
+  CarServer_Response response = CarServer_Response_init_default;
+  response.which_response_msg = CarServer_Response_vehicleData_tag;
+  response.response_msg.vehicleData.has_charge_state = true;
+
+  auto &charge_state = response.response_msg.vehicleData.charge_state;
+  charge_state.which_optional_charge_limit_reason = CarServer_ChargeState_charge_limit_reason_tag;
+  charge_state.optional_charge_limit_reason.charge_limit_reason =
+      CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonEvse;
+
+  pb_byte_t encoded_response[512];
+  size_t encoded_length = sizeof(encoded_response);
+  auto encode_status = pb_encode_fields(encoded_response, &encoded_length, CarServer_Response_fields, &response);
+  ASSERT_EQ(encode_status, TeslaBLE_Status_E_OK) << "Encoding CarServer response should succeed";
+
+  UniversalMessage_RoutableMessage_protobuf_message_as_bytes_t input_buffer;
+  input_buffer.size = encoded_length;
+  memcpy(input_buffer.bytes, encoded_response, encoded_length);
+
+  CarServer_Response parsed_response = CarServer_Response_init_default;
+  Signatures_SignatureData signature_data = Signatures_SignatureData_init_default;
+  auto parse_status = client_->parse_payload_car_server_response(
+      &input_buffer, &signature_data, 0, UniversalMessage_MessageFault_E_MESSAGEFAULT_ERROR_NONE, 0, &parsed_response);
+
+  ASSERT_EQ(parse_status, TeslaBLE_Status_E_OK) << "Parsing CarServer response should succeed";
+  ASSERT_EQ(parsed_response.which_response_msg, CarServer_Response_vehicleData_tag);
+  ASSERT_TRUE(parsed_response.response_msg.vehicleData.has_charge_state);
+  EXPECT_EQ(parsed_response.response_msg.vehicleData.charge_state.which_optional_charge_limit_reason,
+            CarServer_ChargeState_charge_limit_reason_tag);
+  EXPECT_EQ(parsed_response.response_msg.vehicleData.charge_state.optional_charge_limit_reason.charge_limit_reason,
+            CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonEvse);
 }

--- a/tests/test_vehicle.cpp
+++ b/tests/test_vehicle.cpp
@@ -177,6 +177,38 @@ std::vector<uint8_t> make_plain_infotainment_response() {
   return frame_universal_message(message);
 }
 
+std::vector<uint8_t> make_plain_infotainment_action_error_response(const char *reason) {
+  CarServer_Response response = CarServer_Response_init_default;
+  response.has_actionStatus = true;
+  response.actionStatus.result = CarServer_OperationStatus_E_OPERATIONSTATUS_ERROR;
+
+  if (reason && reason[0] != '\0') {
+    response.actionStatus.has_result_reason = true;
+    response.actionStatus.result_reason.which_reason = CarServer_ResultReason_plain_text_tag;
+    std::strncpy(response.actionStatus.result_reason.reason.plain_text, reason,
+                 sizeof(response.actionStatus.result_reason.reason.plain_text) - 1);
+    response.actionStatus.result_reason.reason
+        .plain_text[sizeof(response.actionStatus.result_reason.reason.plain_text) - 1] = '\0';
+  }
+
+  pb_byte_t response_buffer[256];
+  size_t response_length = sizeof(response_buffer);
+  auto encode_status =
+      TeslaBLE::pb_encode_fields(response_buffer, &response_length, CarServer_Response_fields, &response);
+  if (encode_status != TeslaBLE_Status_E_OK) {
+    return {};
+  }
+
+  UniversalMessage_RoutableMessage message = UniversalMessage_RoutableMessage_init_default;
+  message.has_from_destination = true;
+  message.from_destination.which_sub_destination = UniversalMessage_Destination_domain_tag;
+  message.from_destination.sub_destination.domain = UniversalMessage_Domain_DOMAIN_INFOTAINMENT;
+  message.which_payload = UniversalMessage_RoutableMessage_protobuf_message_as_bytes_tag;
+  message.payload.protobuf_message_as_bytes.size = response_length;
+  std::copy_n(response_buffer, response_length, message.payload.protobuf_message_as_bytes.bytes);
+  return frame_universal_message(message);
+}
+
 std::vector<uint8_t> make_session_info_with_status(const pb_byte_t *request_uuid, size_t request_uuid_length,
                                                    const pb_byte_t *mock_message, size_t mock_message_length,
                                                    Signatures_Session_Info_Status status) {
@@ -532,6 +564,62 @@ TEST_F(VehicleTest, InfotainmentPollCompletesOnResponse) {
 
   ASSERT_TRUE(callback_called) << "Infotainment command should complete after response";
   ASSERT_TRUE(callback_success) << "Infotainment command should report success";
+}
+
+TEST_F(VehicleTest, InfotainmentActionFailureSurfacesPlainTextReason) {
+  vehicle_->set_connected(true);
+
+  bool callback_called = false;
+  std::unique_ptr<CommandError> captured_error;
+
+  vehicle_->send_command(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Climate On",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        bool enabled = true;
+        return client->build_car_server_vehicle_action_message(buff, len, CarServer_VehicleAction_hvacAutoAction_tag,
+                                                               &enabled);
+      },
+      [&](std::unique_ptr<CommandError> error) {
+        callback_called = true;
+        captured_error = std::move(error);
+      },
+      true);
+
+  vehicle_->loop();
+  auto initial_writes = mock_ble_->get_written_data();
+  ASSERT_GE(initial_writes.size(), 1);
+  size_t request_uuid_length = 0;
+  auto request_uuid = extract_request_uuid(initial_writes.front(), &request_uuid_length);
+  ASSERT_EQ(request_uuid_length, request_uuid.size());
+
+  auto vcsec_session = make_vcsec_session_info_with_valid_hmac(request_uuid.data(), request_uuid_length);
+  ASSERT_FALSE(vcsec_session.empty());
+  vehicle_->on_rx_data(vcsec_session);
+  vehicle_->loop();
+
+  auto info_writes = mock_ble_->get_written_data();
+  ASSERT_GE(info_writes.size(), 2);
+  size_t infotainment_request_uuid_length = 0;
+  auto infotainment_request_uuid = extract_request_uuid(info_writes.back(), &infotainment_request_uuid_length);
+  ASSERT_EQ(infotainment_request_uuid_length, infotainment_request_uuid.size());
+
+  auto infotainment_session = make_infotainment_session_info_with_valid_hmac(infotainment_request_uuid.data(),
+                                                                             infotainment_request_uuid_length);
+  ASSERT_FALSE(infotainment_session.empty());
+  vehicle_->on_rx_data(infotainment_session);
+  vehicle_->loop();
+
+  auto action_error_frame = make_plain_infotainment_action_error_response("climate keeper unavailable");
+  ASSERT_FALSE(action_error_frame.empty());
+  vehicle_->on_rx_data(action_error_frame);
+  vehicle_->loop();
+
+  ASSERT_TRUE(callback_called) << "Infotainment action should complete with failure";
+  ASSERT_NE(captured_error, nullptr) << "Infotainment action should surface an error";
+  EXPECT_FALSE(captured_error->is_temporary()) << "CarServer action failures should be permanent";
+  EXPECT_FALSE(captured_error->may_have_succeeded()) << "CarServer action failures should be definite failures";
+  EXPECT_TRUE(captured_error->message().find("climate keeper unavailable") != std::string::npos)
+      << "Error should include the vehicle-provided action failure reason: " << captured_error->message();
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- surface infotainment action failures as permanent command errors with vehicle-provided plain text reasons when available
- add regression coverage for CarServer action error propagation
- expand charge-state debug logging and add parsing coverage for charge_limit_reason fields

## Testing
- ./scripts/clang-format.sh --check
- ./build/tests/test_vehicle --gtest_filter=VehicleTest.InfotainmentActionFailureSurfacesPlainTextReason
- ./build/tests/test_message_parsing --gtest_filter=MessageParsingTest.ParsePayloadCarServerResponseChargeLimitReasonOneof