### PR TITLE
fix: align WAITING_FOR_RESPONSE per-attempt timeout with Go reference

### DIFF
--- a/include/vehicle.h
+++ b/include/vehicle.h
@@ -164,7 +164,7 @@ class Vehicle {
   static constexpr auto AUTH_RESPONSE_TIMEOUT =
       std::chrono::seconds(25);  // Time to wait for auth responses (VCSEC/Infotainment)
   static constexpr auto CLOCK_SYNC_MAX_LATENCY =
-      std::chrono::seconds(4);  // Max allowed clock sync error (from Go impl)
+      std::chrono::seconds(4);  // Max age for stale session info responses (from Go impl)
   static constexpr auto TRANSPORT_RETRY_INTERVAL =
       std::chrono::seconds(1);  // Transport-layer retry interval (from Go impl)
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -174,7 +174,7 @@ void TeslaBLE::Vehicle::process_command_queue_() {
       break;
     case CommandState::WAITING_FOR_RESPONSE: {
       auto tx_duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - command->last_tx_at);
-      const auto timeout = (command->name == "Whitelist Add Key") ? COMMAND_TIMEOUT : CLOCK_SYNC_MAX_LATENCY;
+      const auto timeout = (command->name == "Whitelist Add Key") ? COMMAND_TIMEOUT : TRANSPORT_RETRY_INTERVAL;
       if (tx_duration > timeout) {
         if (command->name == "Wake" && is_vehicle_awake_) {
           LOG_INFO("Wake response timeout but vehicle is awake - proceeding");


### PR DESCRIPTION
Change the per-attempt response timeout from CLOCK_SYNC_MAX_LATENCY (4s) to TRANSPORT_RETRY_INTERVAL (1s). The Go reference uses 1s retry granularity and never uses 4s for command response timeouts.

CLOCK_SYNC_MAX_LATENCY is only for discarding stale session-info responses, not for command response deadlines.