### PR TITLE
refactor: explicit command operation lifecycle with wake + phase policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Created by https://www.toptal.com/developers/gitignore/api/intellij,c++,cmake,platformio,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=intellij,c++,cmake,platformio,visualstudiocode
 .vscode
+.opencode
+openspec
 build/
 build-pr-full/
 test.md

--- a/include/vehicle.h
+++ b/include/vehicle.h
@@ -19,6 +19,78 @@ namespace TeslaBLE {
 
 class Client;
 
+enum class SleepState {
+  Unknown,
+  Asleep,
+  Awake,
+};
+
+enum class WakePolicy {
+  NoWakeSkip,
+  NoWakeFail,
+  WakeIfNeeded,
+};
+
+enum class OperationPhase {
+  Queued,
+  EnsuringVcsecSession,
+  EnsuringAwake,
+  EnsuringInfotainmentSession,
+  SendingRequest,
+  AwaitingResponse,
+  Terminal,
+};
+
+enum class OperationOutcome {
+  Success,
+  Skipped,
+  Failed,
+};
+
+enum class OperationTerminalReason {
+  None,
+  VehicleAsleep,
+};
+
+class OperationResult {
+ public:
+  static OperationResult success(OperationTerminalReason reason = OperationTerminalReason::None) {
+    return OperationResult(OperationOutcome::Success, reason, nullptr);
+  }
+
+  static OperationResult skipped(OperationTerminalReason reason) {
+    return OperationResult(OperationOutcome::Skipped, reason, nullptr);
+  }
+
+  static OperationResult failure(std::unique_ptr<CommandError> error,
+                                 OperationTerminalReason reason = OperationTerminalReason::None) {
+    return OperationResult(OperationOutcome::Failed, reason, std::move(error));
+  }
+
+  OperationResult(OperationResult &&) = default;
+  OperationResult &operator=(OperationResult &&) = default;
+
+  OperationResult(const OperationResult &) = delete;
+  OperationResult &operator=(const OperationResult &) = delete;
+
+  OperationOutcome outcome() const { return outcome_; }
+  OperationTerminalReason reason() const { return reason_; }
+  bool is_success() const { return outcome_ == OperationOutcome::Success; }
+  bool is_skipped() const { return outcome_ == OperationOutcome::Skipped; }
+  bool is_failure() const { return outcome_ == OperationOutcome::Failed; }
+  bool compatible_success() const { return outcome_ != OperationOutcome::Failed; }
+  const CommandError *error() const { return error_.get(); }
+  std::unique_ptr<CommandError> release_error() { return std::move(error_); }
+
+ private:
+  OperationResult(OperationOutcome outcome, OperationTerminalReason reason, std::unique_ptr<CommandError> error)
+      : outcome_(outcome), reason_(reason), error_(std::move(error)) {}
+
+  OperationOutcome outcome_;
+  OperationTerminalReason reason_;
+  std::unique_ptr<CommandError> error_;
+};
+
 enum class CommandState {
   IDLE,
   AUTHENTICATING,         // Unified auth initiation state
@@ -34,17 +106,23 @@ class Vehicle;
 struct Command;
 
 struct Command {
+  using OperationResultCallback = std::function<void(OperationResult)>;
+  using OperationPhaseCallback = std::function<void(OperationPhase)>;
+
   UniversalMessage_Domain domain;
   std::string name;
   // Builder function: takes Client pointer, output buffer, output length pointer. Returns status code (0 for success).
   std::function<int(Client *, uint8_t *, size_t *)> builder;
-  // Callback: rich error information instead of boolean
-  std::function<void(std::unique_ptr<CommandError>)> on_complete;
-  // Whether this command requires the vehicle to be awake (write commands = true, read/poll = false)
-  bool requires_wake = true;
+  OperationResultCallback on_complete;
+  OperationPhaseCallback on_phase_change;
+  WakePolicy wake_policy = WakePolicy::WakeIfNeeded;
 
   CommandState state = CommandState::IDLE;
+  OperationPhase phase = OperationPhase::Queued;
+  OperationOutcome outcome = OperationOutcome::Success;
+  OperationTerminalReason terminal_reason = OperationTerminalReason::None;
   std::chrono::steady_clock::time_point started_at;
+  std::chrono::steady_clock::time_point phase_started_at;
   std::chrono::steady_clock::time_point last_tx_at;
   uint8_t retry_count = 0;
 
@@ -59,14 +137,20 @@ struct Command {
   UniversalMessage_Domain current_auth_domain;
 
   Command(UniversalMessage_Domain d, std::string n, std::function<int(Client *, uint8_t *, size_t *)> b,
-          std::function<void(std::unique_ptr<CommandError>)> cb = nullptr, bool wake = true)
+          OperationResultCallback cb = nullptr, WakePolicy wake = WakePolicy::WakeIfNeeded,
+          OperationPhaseCallback phase_cb = nullptr)
       : domain(d),
         name(std::move(n)),
         builder(std::move(b)),
         on_complete(std::move(cb)),
-        requires_wake(wake),
+        on_phase_change(std::move(phase_cb)),
+        wake_policy(wake),
         current_auth_domain(d) {
     started_at = std::chrono::steady_clock::now();
+    phase_started_at = started_at;
+    if (on_phase_change) {
+      on_phase_change(phase);
+    }
   }
 };
 
@@ -78,13 +162,28 @@ class Vehicle {
 
   void on_rx_data(const std::vector<uint8_t> &data);
 
+  // Legacy overloads: bool requires_wake maps to WakePolicy::NoWakeSkip (false) or WakeIfNeeded (true).
+  // The rich-error callback receives nullptr for both success and skipped outcomes; to distinguish
+  // them use send_command_result() with OperationResultCallback instead.
   void send_command(UniversalMessage_Domain domain, const std::string &name,
                     std::function<int(Client *, uint8_t *, size_t *)> builder,
                     std::function<void(std::unique_ptr<CommandError>)> on_complete = nullptr,
                     bool requires_wake = true);
+  void send_command(UniversalMessage_Domain domain, const std::string &name,
+                    std::function<int(Client *, uint8_t *, size_t *)> builder,
+                    std::function<void(std::unique_ptr<CommandError>)> on_complete, WakePolicy wake_policy);
   void send_command_bool(UniversalMessage_Domain domain, const std::string &name,
                          std::function<int(Client *, uint8_t *, size_t *)> builder,
                          const std::function<void(bool)> &on_complete = nullptr, bool requires_wake = true);
+  void send_command_bool(UniversalMessage_Domain domain, const std::string &name,
+                         std::function<int(Client *, uint8_t *, size_t *)> builder,
+                         const std::function<void(bool)> &on_complete, WakePolicy wake_policy);
+  // Primary API for richer phase and outcome semantics.
+  void send_command_result(UniversalMessage_Domain domain, const std::string &name,
+                           std::function<int(Client *, uint8_t *, size_t *)> builder,
+                           Command::OperationResultCallback on_complete,
+                           WakePolicy wake_policy = WakePolicy::WakeIfNeeded,
+                           Command::OperationPhaseCallback on_phase_change = nullptr);
 
   void set_vehicle_status_callback(std::function<void(const VCSEC_VehicleStatus &)> cb) {
     vehicle_status_callback_ = std::move(cb);
@@ -108,11 +207,17 @@ class Vehicle {
   void wake();
   void vcsec_poll();
   void infotainment_poll(bool force_wake = false);
+  void infotainment_poll(WakePolicy wake_policy);
   void charge_state_poll(bool force_wake = false);
+  void charge_state_poll(WakePolicy wake_policy);
   void climate_state_poll(bool force_wake = false);
+  void climate_state_poll(WakePolicy wake_policy);
   void drive_state_poll(bool force_wake = false);
+  void drive_state_poll(WakePolicy wake_policy);
   void closures_state_poll(bool force_wake = false);
+  void closures_state_poll(WakePolicy wake_policy);
   void tire_pressure_poll(bool force_wake = false);
+  void tire_pressure_poll(WakePolicy wake_policy);
 
   void set_charging_state(bool enable);
   void set_charging_amps(int amps);
@@ -151,7 +256,9 @@ class Vehicle {
   bool is_connected() const { return is_connected_; }
   void set_connected(bool connected);
 
-  void set_awake(bool awake) { is_vehicle_awake_ = awake; }
+  void set_awake(bool awake) { sleep_state_ = awake ? SleepState::Awake : SleepState::Asleep; }
+  void set_sleep_state(SleepState state) { sleep_state_ = state; }
+  SleepState sleep_state() const { return sleep_state_; }
 
   void set_vin(const std::string &vin);
   using MessageCallback = std::function<void(const UniversalMessage_RoutableMessage &)>;
@@ -197,7 +304,7 @@ class Vehicle {
   std::function<void(const CarServer_ClosuresState &)> closures_state_callback_;
 
   bool is_connected_ = false;
-  bool is_vehicle_awake_ = false;  // From VCSEC sleep status (inverted: true unless explicitly ASLEEP)
+  SleepState sleep_state_ = SleepState::Unknown;
   bool recovery_attempted_ = false;
 
   static constexpr size_t FRAME_HEADER_SIZE = 2;
@@ -209,12 +316,18 @@ class Vehicle {
   void process_authenticating_command_(const std::shared_ptr<Command> &command);
   void process_auth_response_waiting_command_(const std::shared_ptr<Command> &command);
   void process_ready_command_(const std::shared_ptr<Command> &command);
+  void advance_infotainment_prerequisites_(const std::shared_ptr<Command> &command);
+  void resume_command_after_prerequisite_(const std::shared_ptr<Command> &command);
   void initiate_vcsec_auth_(const std::shared_ptr<Command> &command);
   void initiate_infotainment_auth_(const std::shared_ptr<Command> &command);
   void initiate_wake_sequence_(const std::shared_ptr<Command> &command);
+  void set_command_phase_(const std::shared_ptr<Command> &command, OperationPhase phase);
   void mark_command_failed_(const std::shared_ptr<Command> &command, std::unique_ptr<CommandError> error);
+  void mark_command_failed_(const std::shared_ptr<Command> &command, std::unique_ptr<CommandError> error,
+                            OperationTerminalReason reason);
   void mark_command_completed_(const std::shared_ptr<Command> &command);
-  void finalize_command_(const std::shared_ptr<Command> &command, std::unique_ptr<CommandError> error);
+  void mark_command_skipped_(const std::shared_ptr<Command> &command, OperationTerminalReason reason);
+  void finalize_command_(const std::shared_ptr<Command> &command, OperationResult result);
   bool is_domain_authenticated_(UniversalMessage_Domain domain);
   void handle_authentication_response_(UniversalMessage_Domain domain, bool success);
   void load_session_from_storage_(UniversalMessage_Domain domain);
@@ -226,6 +339,8 @@ class Vehicle {
   bool attempt_buffer_recovery_(int &msg_len);
   void log_timeout_message_(const std::string &message, const std::shared_ptr<Command> &command);
   void handle_vehicle_status_command_update_(const std::shared_ptr<Command> &cmd, const VCSEC_VehicleStatus &status);
+  bool is_vehicle_observed_awake_() const;
+  bool is_vehicle_observed_asleep_() const;
 
  public:
   void retry_command(const std::shared_ptr<Command> &command);
@@ -245,7 +360,7 @@ class Vehicle {
   void handle_infotainment_auth_timeout_(const std::shared_ptr<Command> &command);
   void handle_wake_response_timeout_(const std::shared_ptr<Command> &command);
   void handle_signed_message_error_(const UniversalMessage_RoutableMessage &msg, bool &has_session_error);
-  void send_infotainment_poll_(const std::string &name, int32_t data_type, bool force_wake = false);
+  void send_infotainment_poll_(const std::string &name, int32_t data_type, WakePolicy wake_policy);
   void initiate_auth_for_domain_(const std::shared_ptr<Command> &command, UniversalMessage_Domain domain,
                                  CommandState waiting_state, const std::string &domain_name);
   bool persist_private_key_();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -24,6 +24,10 @@ namespace TeslaBLE {
 
 namespace {
 
+WakePolicy wake_policy_from_bool(bool requires_wake) {
+  return requires_wake ? WakePolicy::WakeIfNeeded : WakePolicy::NoWakeSkip;
+}
+
 std::unique_ptr<CommandError> build_carserver_action_error(const CarServer_ActionStatus &status) {
   std::string message = "Infotainment action failed";
   if (status.has_result_reason && status.result_reason.which_reason == CarServer_ResultReason_plain_text_tag) {
@@ -84,12 +88,12 @@ void TeslaBLE::Vehicle::set_connected(bool connected) {
       info_peer->reset();
     }
 
-    is_vehicle_awake_ = false;
+    sleep_state_ = SleepState::Unknown;
 
     while (!command_queue_.empty()) {
       auto cmd = command_queue_.front();
       if (cmd->on_complete) {
-        cmd->on_complete(CommandError::connection_lost());  // Notify failure
+        cmd->on_complete(OperationResult::failure(CommandError::connection_lost()));
       }
       command_queue_.pop();
     }
@@ -111,10 +115,33 @@ void TeslaBLE::Vehicle::send_command(UniversalMessage_Domain domain, const std::
                                      std::function<int(Client *, uint8_t *, size_t *)> builder,
                                      std::function<void(std::unique_ptr<CommandError>)> on_complete,
                                      bool requires_wake) {
+  send_command(domain, name, std::move(builder), std::move(on_complete), wake_policy_from_bool(requires_wake));
+}
+
+void TeslaBLE::Vehicle::send_command(UniversalMessage_Domain domain, const std::string &name,
+                                     std::function<int(Client *, uint8_t *, size_t *)> builder,
+                                     std::function<void(std::unique_ptr<CommandError>)> on_complete,
+                                     WakePolicy wake_policy) {
+  auto rich_callback = on_complete
+                           ? [callback = std::move(on_complete)](OperationResult result) mutable {
+                               if (result.is_failure()) {
+                                 callback(result.release_error());
+                                 return;
+                               }
+                               callback(nullptr);
+                             }
+                           : Command::OperationResultCallback(nullptr);
+  send_command_result(domain, name, std::move(builder), std::move(rich_callback), wake_policy);
+}
+
+void TeslaBLE::Vehicle::send_command_result(UniversalMessage_Domain domain, const std::string &name,
+                                            std::function<int(Client *, uint8_t *, size_t *)> builder,
+                                            Command::OperationResultCallback on_complete, WakePolicy wake_policy,
+                                            Command::OperationPhaseCallback on_phase_change) {
   if (!is_connected_) {
     LOG_DEBUG("Not connected - rejecting command: %s", name.c_str());
     if (on_complete) {
-      on_complete(CommandError::connection_lost());
+      on_complete(OperationResult::failure(CommandError::connection_lost()));
     }
     return;
   }
@@ -122,23 +149,30 @@ void TeslaBLE::Vehicle::send_command(UniversalMessage_Domain domain, const std::
   if (command_queue_.size() >= MAX_COMMAND_QUEUE_SIZE) {
     LOG_WARNING("Command queue full, rejecting command: %s", name.c_str());
     if (on_complete) {
-      on_complete(CommandError::build_failed("queue full"));
+      on_complete(OperationResult::failure(CommandError::build_failed("queue full")));
     }
     return;
   }
 
-  auto cmd = std::make_shared<Command>(domain, name, std::move(builder), std::move(on_complete), requires_wake);
+  auto cmd = std::make_shared<Command>(domain, name, std::move(builder), std::move(on_complete), wake_policy,
+                                       std::move(on_phase_change));
   command_queue_.push(cmd);
-  LOG_DEBUG("Enqueued command: %s (domain: %s, requires_wake: %s)", cmd->name.c_str(), domain_to_string(domain),
-            requires_wake ? "true" : "false");
+  LOG_DEBUG("Enqueued command: %s (domain: %s, wake_policy: %d)", cmd->name.c_str(), domain_to_string(domain),
+            static_cast<int>(wake_policy));
 }
 
 void TeslaBLE::Vehicle::send_command_bool(UniversalMessage_Domain domain, const std::string &name,
                                           std::function<int(Client *, uint8_t *, size_t *)> builder,
                                           const std::function<void(bool)> &on_complete, bool requires_wake) {
-  auto rich_callback = on_complete ? [on_complete](std::unique_ptr<CommandError> error) { on_complete(!error); }
-                                   : std::function<void(std::unique_ptr<CommandError>)>(nullptr);
-  send_command(domain, name, std::move(builder), std::move(rich_callback), requires_wake);
+  send_command_bool(domain, name, std::move(builder), on_complete, wake_policy_from_bool(requires_wake));
+}
+
+void TeslaBLE::Vehicle::send_command_bool(UniversalMessage_Domain domain, const std::string &name,
+                                          std::function<int(Client *, uint8_t *, size_t *)> builder,
+                                          const std::function<void(bool)> &on_complete, WakePolicy wake_policy) {
+  auto rich_callback = on_complete ? [on_complete](OperationResult result) { on_complete(result.compatible_success()); }
+                                   : Command::OperationResultCallback(nullptr);
+  send_command_result(domain, name, std::move(builder), std::move(rich_callback), wake_policy);
 }
 
 void TeslaBLE::Vehicle::process_command_queue_() {
@@ -148,14 +182,21 @@ void TeslaBLE::Vehicle::process_command_queue_() {
 
   auto command = command_queue_.front();
   auto now = std::chrono::steady_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - command->started_at);
-  if (duration > COMMAND_TIMEOUT) {
+  auto phase_duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - command->phase_started_at);
+  const auto step_timeout =
+      (command->state == CommandState::WAITING_FOR_RESPONSE || command->state == CommandState::READY)
+          ? CLOCK_SYNC_MAX_LATENCY
+          : AUTH_RESPONSE_TIMEOUT;
+  if (phase_duration > step_timeout && command->state != CommandState::WAITING_FOR_RESPONSE &&
+      command->state != CommandState::READY && command->state != CommandState::AUTH_RESPONSE_WAITING) {
     if (is_connected_) {
-      LOG_WARNING("Command timeout while connected: %s", command->name.c_str());
+      LOG_WARNING("Command step timeout while connected: %s (phase: %d)", command->name.c_str(),
+                  static_cast<int>(command->phase));
     } else {
-      LOG_DEBUG("Command timeout while disconnected: %s", command->name.c_str());
+      LOG_DEBUG("Command step timeout while disconnected: %s (phase: %d)", command->name.c_str(),
+                static_cast<int>(command->phase));
     }
-    mark_command_failed_(command, CommandError::timeout("Command"));
+    mark_command_failed_(command, CommandError::timeout("Command step"));
     return;
   }
 
@@ -176,7 +217,7 @@ void TeslaBLE::Vehicle::process_command_queue_() {
       auto tx_duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - command->last_tx_at);
       const auto timeout = (command->name == "Whitelist Add Key") ? COMMAND_TIMEOUT : TRANSPORT_RETRY_INTERVAL;
       if (tx_duration > timeout) {
-        if (command->name == "Wake" && is_vehicle_awake_) {
+        if (command->name == "Wake" && is_vehicle_observed_awake_()) {
           LOG_INFO("Wake response timeout but vehicle is awake - proceeding");
           mark_command_completed_(command);
           break;
@@ -237,10 +278,12 @@ void TeslaBLE::Vehicle::process_authenticating_command_(const std::shared_ptr<Co
     case UniversalMessage_Domain_DOMAIN_INFOTAINMENT:
       if (!is_domain_authenticated_(UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY)) {
         LOG_DEBUG("VCSEC auth required before Infotainment auth");
+        set_command_phase_(command, OperationPhase::EnsuringVcsecSession);
         command->current_auth_domain = UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY;
         initiate_auth_for_domain_(command, UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY,
                                   CommandState::AUTH_RESPONSE_WAITING, "VCSEC");
       } else {
+        set_command_phase_(command, OperationPhase::EnsuringInfotainmentSession);
         initiate_auth_for_domain_(command, UniversalMessage_Domain_DOMAIN_INFOTAINMENT,
                                   CommandState::AUTH_RESPONSE_WAITING, "Infotainment");
       }
@@ -305,7 +348,7 @@ void TeslaBLE::Vehicle::handle_infotainment_auth_timeout_(const std::shared_ptr<
 
 void TeslaBLE::Vehicle::handle_wake_response_timeout_(const std::shared_ptr<Command> &command) {
   // Check if vehicle woke up (we may have received status update even without wake response)
-  if (is_vehicle_awake_) {
+  if (is_vehicle_observed_awake_()) {
     LOG_INFO("Wake response timeout but vehicle is awake - proceeding");
     if (command->domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
       command->current_auth_domain = UniversalMessage_Domain_DOMAIN_INFOTAINMENT;
@@ -325,9 +368,11 @@ void TeslaBLE::Vehicle::initiate_auth_for_domain_(const std::shared_ptr<Command>
                                                   const std::string &domain_name) {
   if (is_domain_authenticated_(domain)) {
     if (command->domain == domain) {
+      set_command_phase_(command, OperationPhase::SendingRequest);
       command->state = CommandState::READY;
-    } else if (domain == UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY) {
-      command->state = CommandState::AUTHENTICATING;
+    } else if (domain == UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY &&
+               command->domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
+      resume_command_after_prerequisite_(command);
     }
   } else {
     uint8_t buffer[256];
@@ -350,33 +395,65 @@ void TeslaBLE::Vehicle::initiate_auth_for_domain_(const std::shared_ptr<Command>
 
 void TeslaBLE::Vehicle::initiate_vcsec_auth_(const std::shared_ptr<Command> &command) {
   command->current_auth_domain = UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY;
+  set_command_phase_(command, OperationPhase::EnsuringVcsecSession);
   initiate_auth_for_domain_(command, UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY,
                             CommandState::AUTH_RESPONSE_WAITING, "VCSEC");
 }
 
 void TeslaBLE::Vehicle::initiate_infotainment_auth_(const std::shared_ptr<Command> &command) {
-  if (!is_vehicle_awake_ && !command->requires_wake) {
-    LOG_DEBUG("Vehicle asleep, skipping optional command: %s", command->name.c_str());
-    mark_command_completed_(command);
-    return;
+  set_command_phase_(command, OperationPhase::Queued);
+
+  switch (command->wake_policy) {
+    case WakePolicy::NoWakeSkip:
+      if (is_vehicle_observed_asleep_()) {
+        LOG_DEBUG("Vehicle asleep, skipping command with NoWakeSkip: %s", command->name.c_str());
+        mark_command_skipped_(command, OperationTerminalReason::VehicleAsleep);
+        return;
+      }
+      break;
+    case WakePolicy::NoWakeFail:
+      if (is_vehicle_observed_asleep_()) {
+        LOG_DEBUG("Vehicle asleep, failing command with NoWakeFail: %s", command->name.c_str());
+        mark_command_failed_(command, CommandError::build_failed("vehicle asleep"),
+                             OperationTerminalReason::VehicleAsleep);
+        return;
+      }
+      break;
+    case WakePolicy::WakeIfNeeded:
+      break;
   }
+
+  advance_infotainment_prerequisites_(command);
+}
+
+void TeslaBLE::Vehicle::advance_infotainment_prerequisites_(const std::shared_ptr<Command> &command) {
   if (!is_domain_authenticated_(UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY)) {
     LOG_DEBUG("VCSEC auth required before Infotainment auth");
+    set_command_phase_(command, OperationPhase::EnsuringVcsecSession);
     initiate_vcsec_auth_(command);
     return;
   }
-  if (!is_vehicle_awake_ && command->requires_wake) {
-    LOG_DEBUG("Vehicle is asleep and command requires wake, initiating wake sequence");
+
+  if (!is_vehicle_observed_awake_() && command->wake_policy == WakePolicy::WakeIfNeeded) {
+    LOG_DEBUG("Vehicle is not awake and wake policy requires wake, initiating wake sequence");
+    set_command_phase_(command, OperationPhase::EnsuringAwake);
     command->current_auth_domain = UniversalMessage_Domain_DOMAIN_BROADCAST;
     command->state = CommandState::AUTHENTICATING;
     command->last_tx_at = std::chrono::steady_clock::time_point();
     return;
   }
+
+  set_command_phase_(command, OperationPhase::EnsuringInfotainmentSession);
   initiate_auth_for_domain_(command, UniversalMessage_Domain_DOMAIN_INFOTAINMENT, CommandState::AUTH_RESPONSE_WAITING,
                             "Infotainment");
 }
 
+void TeslaBLE::Vehicle::resume_command_after_prerequisite_(const std::shared_ptr<Command> &command) {
+  advance_infotainment_prerequisites_(command);
+}
+
 void TeslaBLE::Vehicle::initiate_wake_sequence_(const std::shared_ptr<Command> &command) {
+  set_command_phase_(command, OperationPhase::EnsuringAwake);
   uint8_t buffer[256];
   size_t len = 256;
   if (client_->build_vcsec_action_message(VCSEC_RKEAction_E_RKE_ACTION_WAKE_VEHICLE, buffer, &len) == 0) {
@@ -433,6 +510,7 @@ void TeslaBLE::Vehicle::retry_command(const std::shared_ptr<Command> &command) {
             static_cast<long long>(backoff_delay.count()), command->name.c_str());
   command->last_tx_at = std::chrono::steady_clock::now() - backoff_delay + std::chrono::milliseconds(100);
 
+  set_command_phase_(command, OperationPhase::Queued);
   switch (command->state) {
     case CommandState::WAITING_FOR_RESPONSE:
       command->state = CommandState::READY;
@@ -445,6 +523,7 @@ void TeslaBLE::Vehicle::retry_command(const std::shared_ptr<Command> &command) {
 }
 
 void TeslaBLE::Vehicle::process_ready_command_(const std::shared_ptr<Command> &command) {
+  set_command_phase_(command, OperationPhase::SendingRequest);
   uint8_t buffer[256];
   size_t len = 256;
   if (command->builder(client_.get(), buffer, &len) == 0) {
@@ -452,6 +531,7 @@ void TeslaBLE::Vehicle::process_ready_command_(const std::shared_ptr<Command> &c
     if (ble_adapter_->write(data)) {
       LOG_DEBUG("Sent command: %s (%zu bytes)", command->name.c_str(), data.size());
       command->state = CommandState::WAITING_FOR_RESPONSE;
+      set_command_phase_(command, OperationPhase::AwaitingResponse);
       command->last_tx_at = std::chrono::steady_clock::now();
     } else {
       LOG_ERROR("Failed to write command data: %s", command->name.c_str());
@@ -471,26 +551,58 @@ void TeslaBLE::Vehicle::mark_command_failed_(const std::shared_ptr<Command> &com
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - command->started_at);
   LOG_ERROR("[%s] Command failed after %lld ms: %s", command->name.c_str(), (long long) duration.count(),
             command->last_error->message().c_str());
-  finalize_command_(command, std::move(command->last_error));
+  finalize_command_(command, OperationResult::failure(std::move(command->last_error)));
+}
+
+void TeslaBLE::Vehicle::mark_command_failed_(const std::shared_ptr<Command> &command,
+                                             std::unique_ptr<CommandError> error, OperationTerminalReason reason) {
+  command->state = CommandState::FAILED;
+  command->last_error = std::move(error);
+  auto now = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - command->started_at);
+  LOG_ERROR("[%s] Command failed after %lld ms: %s (reason: %d)", command->name.c_str(), (long long) duration.count(),
+            command->last_error->message().c_str(), static_cast<int>(reason));
+  finalize_command_(command, OperationResult::failure(std::move(command->last_error), reason));
 }
 
 void TeslaBLE::Vehicle::mark_command_completed_(const std::shared_ptr<Command> &command) {
   command->state = CommandState::COMPLETED;
+  set_command_phase_(command, OperationPhase::Terminal);
   auto now = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - command->started_at);
   LOG_INFO("[%s] Command completed successfully in %lld ms", command->name.c_str(), (long long) duration.count());
-  finalize_command_(command, nullptr);
+  finalize_command_(command, OperationResult::success());
 }
 
-void TeslaBLE::Vehicle::finalize_command_(const std::shared_ptr<Command> &command,
-                                          std::unique_ptr<CommandError> error) {
+void TeslaBLE::Vehicle::mark_command_skipped_(const std::shared_ptr<Command> &command, OperationTerminalReason reason) {
+  command->state = CommandState::COMPLETED;
+  set_command_phase_(command, OperationPhase::Terminal);
+  LOG_INFO("[%s] Command skipped (reason: %d)", command->name.c_str(), static_cast<int>(reason));
+  finalize_command_(command, OperationResult::skipped(reason));
+}
+
+void TeslaBLE::Vehicle::set_command_phase_(const std::shared_ptr<Command> &command, OperationPhase phase) {
+  if (command->phase == phase)
+    return;
+  command->phase = phase;
+  command->phase_started_at = std::chrono::steady_clock::now();
+  if (command->on_phase_change) {
+    command->on_phase_change(phase);
+  }
+}
+
+void TeslaBLE::Vehicle::finalize_command_(const std::shared_ptr<Command> &command, OperationResult result) {
   if (command->on_complete) {
-    command->on_complete(std::move(error));
+    command->on_complete(std::move(result));
   }
   if (!command_queue_.empty() && command_queue_.front() == command) {
     command_queue_.pop();
   }
 }
+
+bool Vehicle::is_vehicle_observed_awake_() const { return sleep_state_ == SleepState::Awake; }
+
+bool Vehicle::is_vehicle_observed_asleep_() const { return sleep_state_ == SleepState::Asleep; }
 
 bool Vehicle::is_domain_authenticated_(UniversalMessage_Domain domain) {
   auto *peer = client_->get_peer(domain);
@@ -766,8 +878,10 @@ void TeslaBLE::Vehicle::handle_vcsec_message_(const UniversalMessage_RoutableMes
     case VCSEC_FromVCSECMessage_vehicleStatus_tag:
       LOG_DEBUG("Received vehicle status");
       log_vehicle_status(TESLA_LOG_TAG, &vcsec_msg.sub_message.vehicleStatus);
-      is_vehicle_awake_ = vcsec_msg.sub_message.vehicleStatus.vehicleSleepStatus !=
-                          VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_ASLEEP;
+      sleep_state_ = vcsec_msg.sub_message.vehicleStatus.vehicleSleepStatus !=
+                             VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_ASLEEP
+                         ? SleepState::Awake
+                         : SleepState::Asleep;
       if (vehicle_status_callback_) {
         vehicle_status_callback_(vcsec_msg.sub_message.vehicleStatus);
       }
@@ -853,10 +967,10 @@ void TeslaBLE::Vehicle::handle_authentication_response_(UniversalMessage_Domain 
   if (success) {
     if (domain == UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY &&
         cmd->domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
-      cmd->current_auth_domain = UniversalMessage_Domain_DOMAIN_INFOTAINMENT;
-      cmd->state = CommandState::AUTHENTICATING;
+      resume_command_after_prerequisite_(cmd);
       return;
     }
+    set_command_phase_(cmd, OperationPhase::SendingRequest);
     cmd->state = CommandState::READY;
     return;
   }
@@ -934,12 +1048,12 @@ void TeslaBLE::Vehicle::handle_vehicle_status_command_update_(const std::shared_
                                                               const VCSEC_VehicleStatus &status) {
   switch (cmd->state) {
     case CommandState::AUTH_RESPONSE_WAITING:
-      if (is_vehicle_awake_ || status.has_closureStatuses) {
+      if (is_vehicle_observed_awake_() || status.has_closureStatuses) {
         LOG_INFO("Vehicle is awake");
         if (cmd->domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
           LOG_DEBUG("Transitioning infotainment command to auth state after wake");
-          // Restart the command timeout budget now that wake succeeded and infotainment auth can begin.
-          cmd->started_at = std::chrono::steady_clock::now();
+          // Restart the step timeout budget now that wake succeeded and infotainment auth can begin.
+          set_command_phase_(cmd, OperationPhase::EnsuringInfotainmentSession);
           cmd->current_auth_domain = UniversalMessage_Domain_DOMAIN_INFOTAINMENT;
           cmd->state = CommandState::AUTHENTICATING;
         } else {
@@ -1039,7 +1153,7 @@ void TeslaBLE::Vehicle::load_session_from_storage_(UniversalMessage_Domain domai
 }
 
 void TeslaBLE::Vehicle::wake() {
-  if (is_vehicle_awake_) {
+  if (is_vehicle_observed_awake_()) {
     LOG_DEBUG("Vehicle is already awake, skipping redundant wake action");
     return;
   }
@@ -1056,41 +1170,53 @@ void TeslaBLE::Vehicle::vcsec_poll() {
                });
 }
 
-void TeslaBLE::Vehicle::infotainment_poll(bool force_wake) {
-  charge_state_poll(force_wake);
-  climate_state_poll(force_wake);
-  drive_state_poll(force_wake);
-  closures_state_poll(force_wake);
-  tire_pressure_poll(force_wake);
+void TeslaBLE::Vehicle::infotainment_poll(bool force_wake) { infotainment_poll(wake_policy_from_bool(force_wake)); }
+
+void TeslaBLE::Vehicle::infotainment_poll(WakePolicy wake_policy) {
+  charge_state_poll(wake_policy);
+  climate_state_poll(wake_policy);
+  drive_state_poll(wake_policy);
+  closures_state_poll(wake_policy);
+  tire_pressure_poll(wake_policy);
 }
 
-void TeslaBLE::Vehicle::send_infotainment_poll_(const std::string &name, int32_t data_type, bool force_wake) {
-  send_command(
+void TeslaBLE::Vehicle::send_infotainment_poll_(const std::string &name, int32_t data_type, WakePolicy wake_policy) {
+  send_command_result(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, name,
       [data_type](Client *client, uint8_t *buff, size_t *len) {
         return client->build_car_server_get_vehicle_data_message(buff, len, data_type);
       },
-      nullptr, force_wake);
+      nullptr, wake_policy);
 }
 
-void TeslaBLE::Vehicle::charge_state_poll(bool force_wake) {
-  send_infotainment_poll_("Charge State Poll", CarServer_GetVehicleData_getChargeState_tag, force_wake);
+void TeslaBLE::Vehicle::charge_state_poll(bool force_wake) { charge_state_poll(wake_policy_from_bool(force_wake)); }
+
+void TeslaBLE::Vehicle::charge_state_poll(WakePolicy wake_policy) {
+  send_infotainment_poll_("Charge State Poll", CarServer_GetVehicleData_getChargeState_tag, wake_policy);
 }
 
-void TeslaBLE::Vehicle::climate_state_poll(bool force_wake) {
-  send_infotainment_poll_("Climate State Poll", CarServer_GetVehicleData_getClimateState_tag, force_wake);
+void TeslaBLE::Vehicle::climate_state_poll(bool force_wake) { climate_state_poll(wake_policy_from_bool(force_wake)); }
+
+void TeslaBLE::Vehicle::climate_state_poll(WakePolicy wake_policy) {
+  send_infotainment_poll_("Climate State Poll", CarServer_GetVehicleData_getClimateState_tag, wake_policy);
 }
 
-void TeslaBLE::Vehicle::drive_state_poll(bool force_wake) {
-  send_infotainment_poll_("Drive State Poll", CarServer_GetVehicleData_getDriveState_tag, force_wake);
+void TeslaBLE::Vehicle::drive_state_poll(bool force_wake) { drive_state_poll(wake_policy_from_bool(force_wake)); }
+
+void TeslaBLE::Vehicle::drive_state_poll(WakePolicy wake_policy) {
+  send_infotainment_poll_("Drive State Poll", CarServer_GetVehicleData_getDriveState_tag, wake_policy);
 }
 
-void TeslaBLE::Vehicle::closures_state_poll(bool force_wake) {
-  send_infotainment_poll_("Closures State Poll", CarServer_GetVehicleData_getClosuresState_tag, force_wake);
+void TeslaBLE::Vehicle::closures_state_poll(bool force_wake) { closures_state_poll(wake_policy_from_bool(force_wake)); }
+
+void TeslaBLE::Vehicle::closures_state_poll(WakePolicy wake_policy) {
+  send_infotainment_poll_("Closures State Poll", CarServer_GetVehicleData_getClosuresState_tag, wake_policy);
 }
 
-void TeslaBLE::Vehicle::tire_pressure_poll(bool force_wake) {
-  send_infotainment_poll_("Tire Pressure Poll", CarServer_GetVehicleData_getTirePressureState_tag, force_wake);
+void TeslaBLE::Vehicle::tire_pressure_poll(bool force_wake) { tire_pressure_poll(wake_policy_from_bool(force_wake)); }
+
+void TeslaBLE::Vehicle::tire_pressure_poll(WakePolicy wake_policy) {
+  send_infotainment_poll_("Tire Pressure Poll", CarServer_GetVehicleData_getTirePressureState_tag, wake_policy);
 }
 
 void TeslaBLE::Vehicle::set_charging_state(bool enable) {

--- a/tests/test_vehicle.cpp
+++ b/tests/test_vehicle.cpp
@@ -515,6 +515,7 @@ TEST_F(VehicleTest, InfotainmentPollWithForceWakeSendsData) {
 
 TEST_F(VehicleTest, InfotainmentPollCompletesOnResponse) {
   vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
 
   bool callback_called = false;
   bool callback_success = false;
@@ -568,6 +569,7 @@ TEST_F(VehicleTest, InfotainmentPollCompletesOnResponse) {
 
 TEST_F(VehicleTest, InfotainmentActionFailureSurfacesPlainTextReason) {
   vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
 
   bool callback_called = false;
   std::unique_ptr<CommandError> captured_error;
@@ -633,6 +635,7 @@ TEST_F(VehicleTest, InfotainmentPollSkippedWhenAsleepByDefault) {
   // Verify default behavior: vehicle starts in asleep state (no VCSEC status received)
   // and infotainment polls without force_wake should be skipped
   vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
 
   bool poll_callback_called = false;
   bool poll_success = false;
@@ -651,9 +654,9 @@ TEST_F(VehicleTest, InfotainmentPollSkippedWhenAsleepByDefault) {
   );
   vehicle_->loop();
 
-  // Poll should be skipped (no BLE writes) but callback invoked with success
+  // Poll should be skipped (no BLE writes) but callback invoked with compatible_success()
   ASSERT_TRUE(poll_callback_called) << "Callback should be invoked for skipped poll";
-  ASSERT_TRUE(poll_success) << "Skipped poll should report success (no-op)";
+  ASSERT_TRUE(poll_success) << "Skipped poll should report compatible_success (no-op)";
 
   auto writes = mock_ble_->get_written_data();
   EXPECT_EQ(writes.size(), 0) << "Poll should be skipped when vehicle is asleep";
@@ -842,6 +845,7 @@ TEST_F(VehicleTest, InfotainmentPollWithoutForceWakeSkipsWhenAsleep) {
 
   // Send poll that doesn't require wake
   vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
   vehicle_->send_command_bool(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Infotainment Poll",
       [](Client *client, uint8_t *buff, size_t *len) {
@@ -1435,6 +1439,333 @@ TEST_F(VehicleTest, PairingBypassesAuthEvenWhenVcsecAuthIsFailing) {
 }
 
 // ============================================================================
+// Wake Policy Regression Tests (4.1)
+// ============================================================================
+
+TEST_F(VehicleTest, NoWakeSkipSkipsWhenVehicleAsleep) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+
+  bool callback_called = false;
+  bool callback_success = false;
+
+  vehicle_->send_command_bool(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "NoWakeSkip Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      [&](bool success) {
+        callback_called = true;
+        callback_success = success;
+      },
+      TeslaBLE::WakePolicy::NoWakeSkip);
+
+  vehicle_->loop();
+
+  ASSERT_TRUE(callback_called) << "NoWakeSkip should invoke callback immediately";
+  ASSERT_TRUE(callback_success) << "NoWakeSkip should report compatible_success for skipped";
+  auto writes = mock_ble_->get_written_data();
+  EXPECT_EQ(writes.size(), 0) << "NoWakeSkip should not send BLE data when asleep";
+}
+
+TEST_F(VehicleTest, NoWakeFailWhenVehicleAsleep) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+
+  bool callback_called = false;
+  bool callback_success = true;
+
+  vehicle_->send_command_bool(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "NoWakeFail Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      [&](bool success) {
+        callback_called = true;
+        callback_success = success;
+      },
+      TeslaBLE::WakePolicy::NoWakeFail);
+
+  vehicle_->loop();
+
+  ASSERT_TRUE(callback_called) << "NoWakeFail should invoke callback immediately";
+  ASSERT_FALSE(callback_success) << "NoWakeFail should report failure for asleep vehicle";
+  auto writes = mock_ble_->get_written_data();
+  EXPECT_EQ(writes.size(), 0) << "NoWakeFail should not send BLE data when asleep";
+}
+
+TEST_F(VehicleTest, WakeIfNeededProceedsWhenAwake) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
+
+  vehicle_->send_command_bool(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "WakeIfNeeded Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      nullptr, TeslaBLE::WakePolicy::WakeIfNeeded);
+
+  vehicle_->loop();
+
+  auto writes = mock_ble_->get_written_data();
+  ASSERT_GE(writes.size(), 1) << "WakeIfNeeded with awake vehicle should start auth";
+}
+
+TEST_F(VehicleTest, WakeIfNeededTriggersWakeWhenAsleep) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+
+  vehicle_->send_command_bool(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "WakeIfNeeded Asleep",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      nullptr, TeslaBLE::WakePolicy::WakeIfNeeded);
+
+  vehicle_->loop();
+
+  auto writes = mock_ble_->get_written_data();
+  ASSERT_GE(writes.size(), 1) << "WakeIfNeeded with asleep vehicle should send VCSEC auth before wake";
+}
+
+TEST_F(VehicleTest, WakePolicyRichOutcomeCallbackDistinguishesSkipped) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+
+  bool callback_called = false;
+  TeslaBLE::OperationOutcome captured_outcome = TeslaBLE::OperationOutcome::Failed;
+  TeslaBLE::OperationTerminalReason captured_reason = TeslaBLE::OperationTerminalReason::None;
+
+  vehicle_->send_command_result(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Result Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      [&](TeslaBLE::OperationResult result) {
+        callback_called = true;
+        captured_outcome = result.outcome();
+        captured_reason = result.reason();
+      },
+      TeslaBLE::WakePolicy::NoWakeSkip);
+
+  vehicle_->loop();
+
+  ASSERT_TRUE(callback_called) << "Rich callback should be invoked";
+  EXPECT_EQ(captured_outcome, TeslaBLE::OperationOutcome::Skipped);
+  EXPECT_EQ(captured_reason, TeslaBLE::OperationTerminalReason::VehicleAsleep);
+}
+
+TEST_F(VehicleTest, WakePolicyRichOutcomeCallbackDistinguishesFailed) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+
+  bool callback_called = false;
+  TeslaBLE::OperationOutcome captured_outcome = TeslaBLE::OperationOutcome::Success;
+
+  vehicle_->send_command_result(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Fail Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      [&](TeslaBLE::OperationResult result) {
+        callback_called = true;
+        captured_outcome = result.outcome();
+      },
+      TeslaBLE::WakePolicy::NoWakeFail);
+
+  vehicle_->loop();
+
+  ASSERT_TRUE(callback_called) << "Rich callback should be invoked";
+  EXPECT_EQ(captured_outcome, TeslaBLE::OperationOutcome::Failed);
+}
+
+// ============================================================================
+// Step-Specific Timeout Regression Tests (4.2)
+// ============================================================================
+
+TEST_F(VehicleTest, WakePhaseTimeoutDoesNotConsumeFinalResponseBudget) {
+  vehicle_->set_connected(true);
+
+  vehicle_->send_command_bool(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Post-Wake Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      nullptr, true);
+
+  vehicle_->loop();
+
+  // Establish VCSEC session
+  auto writes = mock_ble_->get_written_data();
+  ASSERT_GE(writes.size(), 1);
+  size_t vcsec_uuid_len = 0;
+  auto vcsec_uuid = extract_request_uuid(writes.front(), &vcsec_uuid_len);
+  ASSERT_EQ(vcsec_uuid_len, vcsec_uuid.size());
+  auto vcsec_session = make_vcsec_session_info_with_valid_hmac(vcsec_uuid.data(), vcsec_uuid_len);
+  ASSERT_FALSE(vcsec_session.empty());
+  vehicle_->on_rx_data(vcsec_session);
+  vehicle_->loop();
+
+  // At this point, sleep state is Unknown and WakeIfNeeded initiates wake.
+  // Simulate the wake phase timing out without a response.
+  auto &command_queue = const_cast<std::queue<std::shared_ptr<Command>> &>(vehicle_->get_command_queue_for_testing());
+  ASSERT_FALSE(command_queue.empty());
+  auto command = command_queue.front();
+  ASSERT_NE(command, nullptr);
+
+  // Command should be in AUTH_RESPONSE_WAITING for the wake phase
+  EXPECT_EQ(command->state, TeslaBLE::CommandState::AUTH_RESPONSE_WAITING);
+  EXPECT_EQ(command->phase, TeslaBLE::OperationPhase::EnsuringAwake);
+
+  // Advance time to exhaust wake-phase timeout but leave total command budget untouched.
+  // Wake timeout is measured from last_tx_at (when wake command was actually sent).
+  command->last_tx_at =
+      std::chrono::steady_clock::now() - TeslaBLE::Vehicle::AUTH_RESPONSE_TIMEOUT - std::chrono::seconds(1);
+  mock_ble_->clear_written_data();
+  vehicle_->loop();
+
+  // Wake timeout should trigger retry (state back to IDLE), not command failure
+  EXPECT_EQ(command->state, TeslaBLE::CommandState::IDLE) << "Wake timeout should trigger retry, not command failure";
+  ASSERT_FALSE(command_queue.empty()) << "Command should remain in queue after retry (not finalized)";
+}
+
+TEST_F(VehicleTest, AuthPhaseTimeoutIndependentFromFinalResponseTimeout) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
+
+  vehicle_->send_command_bool(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Auth Timeout Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      nullptr, true);
+
+  vehicle_->loop();
+
+  // Auth request should be sent
+  auto writes = mock_ble_->get_written_data();
+  ASSERT_GE(writes.size(), 1);
+  mock_ble_->clear_written_data();
+
+  auto &command_queue = const_cast<std::queue<std::shared_ptr<Command>> &>(vehicle_->get_command_queue_for_testing());
+  ASSERT_FALSE(command_queue.empty());
+  auto command = command_queue.front();
+
+  EXPECT_EQ(command->phase, TeslaBLE::OperationPhase::EnsuringVcsecSession);
+
+  // Advance time past auth timeout
+  command->phase_started_at =
+      std::chrono::steady_clock::now() - TeslaBLE::Vehicle::AUTH_RESPONSE_TIMEOUT - std::chrono::seconds(1);
+  vehicle_->loop();
+
+  // Auth timeout should trigger retry, not final command failure
+  ASSERT_FALSE(command_queue.empty()) << "Command should remain in queue after auth retry";
+  EXPECT_NE(command->state, TeslaBLE::CommandState::FAILED) << "Auth phase timeout should retry, not fail the command";
+}
+
+// ============================================================================
+// Wrapper Outcome Distinction Tests (4.3)
+// ============================================================================
+
+TEST_F(VehicleTest, WrapperCanObserveSkippedOutcomeWithoutInspectingInternals) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+
+  TeslaBLE::OperationOutcome outcome = TeslaBLE::OperationOutcome::Failed;
+  TeslaBLE::OperationTerminalReason reason = TeslaBLE::OperationTerminalReason::None;
+  const TeslaBLE::CommandError *err = nullptr;
+
+  vehicle_->send_command_result(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Wrapper Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      [&](TeslaBLE::OperationResult result) {
+        outcome = result.outcome();
+        reason = result.reason();
+        err = result.error();
+      },
+      TeslaBLE::WakePolicy::NoWakeSkip);
+
+  vehicle_->loop();
+
+  EXPECT_EQ(outcome, TeslaBLE::OperationOutcome::Skipped);
+  EXPECT_EQ(reason, TeslaBLE::OperationTerminalReason::VehicleAsleep);
+  EXPECT_EQ(err, nullptr) << "Skipped operations should not carry an error";
+}
+
+TEST_F(VehicleTest, WrapperCanObservePhaseTransitions) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
+
+  std::vector<TeslaBLE::OperationPhase> phases;
+  TeslaBLE::OperationOutcome outcome = TeslaBLE::OperationOutcome::Failed;
+
+  vehicle_->send_command_result(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Phase Observed Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      [&](TeslaBLE::OperationResult result) { outcome = result.outcome(); }, TeslaBLE::WakePolicy::WakeIfNeeded,
+      [&](TeslaBLE::OperationPhase phase) { phases.push_back(phase); });
+
+  vehicle_->loop();
+
+  ASSERT_GE(phases.size(), 1) << "Phase callback should fire at least once";
+  EXPECT_EQ(phases.front(), TeslaBLE::OperationPhase::Queued) << "First phase should be Queued";
+
+  auto writes = mock_ble_->get_written_data();
+  ASSERT_GE(writes.size(), 1);
+  size_t vcsec_uuid_len = 0;
+  auto vcsec_uuid = extract_request_uuid(writes.front(), &vcsec_uuid_len);
+  ASSERT_EQ(vcsec_uuid_len, vcsec_uuid.size());
+  auto vcsec_session = make_vcsec_session_info_with_valid_hmac(vcsec_uuid.data(), vcsec_uuid_len);
+  ASSERT_FALSE(vcsec_session.empty());
+  vehicle_->on_rx_data(vcsec_session);
+  vehicle_->loop();
+
+  ASSERT_GE(phases.size(), 2) << "Should see Queued → EnsuringVcsecSession → EnsuringInfotainmentSession phases";
+  EXPECT_EQ(phases[1], TeslaBLE::OperationPhase::EnsuringVcsecSession);
+}
+
+TEST_F(VehicleTest, WrapperCompatibleSuccessPreservesExistingBoolSemantics) {
+  vehicle_->set_connected(true);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+
+  bool callback_called = false;
+  bool callback_success = false;
+
+  vehicle_->send_command_bool(
+      UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Compat Poll",
+      [](Client *client, uint8_t *buff, size_t *len) {
+        return client->build_car_server_get_vehicle_data_message(buff, len,
+                                                                 CarServer_GetVehicleData_getChargeState_tag);
+      },
+      [&](bool success) {
+        callback_called = true;
+        callback_success = success;
+      },
+      TeslaBLE::WakePolicy::NoWakeSkip);
+
+  vehicle_->loop();
+
+  ASSERT_TRUE(callback_called);
+  ASSERT_TRUE(callback_success) << "compatible_success should be true for skipped operations";
+  auto writes = mock_ble_->get_written_data();
+  EXPECT_EQ(writes.size(), 0) << "No BLE writes should occur for skipped NoWakeSkip";
+}
+
+// ============================================================================
 // Command Struct Tests
 // ============================================================================
 
@@ -1443,15 +1774,16 @@ TEST(CommandStructTest, DefaultRequiresWakeIsTrue) {
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Test Command",
       [](Client *, uint8_t *, size_t *) { return TeslaBLE_Status_E_OK; }, nullptr);
 
-  ASSERT_TRUE(cmd.requires_wake) << "Commands should default to requiring wake for safety";
+  ASSERT_EQ(cmd.wake_policy, TeslaBLE::WakePolicy::WakeIfNeeded)
+      << "Commands should default to requiring wake for safety";
 }
 
 TEST(CommandStructTest, RequiresWakeCanBeSetFalse) {
   Command cmd(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Test Poll",
-      [](Client *, uint8_t *, size_t *) { return TeslaBLE_Status_E_OK; }, nullptr, false);
+      [](Client *, uint8_t *, size_t *) { return TeslaBLE_Status_E_OK; }, nullptr, TeslaBLE::WakePolicy::NoWakeSkip);
 
-  ASSERT_FALSE(cmd.requires_wake);
+  ASSERT_EQ(cmd.wake_policy, TeslaBLE::WakePolicy::NoWakeSkip);
 }
 
 // ============================================================================


### PR DESCRIPTION
Replace the monolithic boolean wake/requires_wake model with explicit
prerequisite-phase orchestration:

- Add SleepState (Unknown/Asleep/Awake), WakePolicy (NoWakeSkip,
  NoWakeFail, WakeIfNeeded), OperationPhase, OperationOutcome, and
  OperationResult types
- Refactor infotainment command execution into explicit prerequisites:
  VCSEC session → wake check → infotainment session → send → response
- Separate timeout budgets per operation step using phase_started_at
- Add OperationResultCallback and OperationPhaseCallback for wrapper
  observation without leaking CommandState internals
- Preserve backward-compatible send_command/send_command_bool overloads
  that map bool to WakePolicy and collapse skipped into
  compatible_success
- Add 10 regression tests covering skip/fail/wake policies,
  step-specific
  timeouts, and wrapper outcome distinction

All 232 tests pass.
