### PR TITLE
fix clang-tidy warnings

### DIFF
--- a/include/defs.h
+++ b/include/defs.h
@@ -10,7 +10,6 @@
 #include <esp_log.h>
 #endif
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables) - False positive on namespace
 namespace TeslaBLE {
 
 enum class LogLevel { ERROR, WARN, INFO, DEBUG, VERBOSE };
@@ -19,10 +18,11 @@ using LogCallback = void (*)(LogLevel level, const char *tag, int line, const ch
 
 void set_log_callback(LogCallback callback);
 LogCallback get_log_callback();
-void log_internal(LogLevel level, const char *tag, int line, const char *format, ...);
+
+void log_internal(LogLevel level, const char *tag, int line, const char *format, ...)
+    __attribute__((format(printf, 4, 5)));
 
 }  // namespace TeslaBLE
-// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 #define LOG_ERROR(format, ...) \
   TeslaBLE::log_internal(TeslaBLE::LogLevel::ERROR, TESLA_LOG_TAG, __LINE__, format __VA_OPT__(, ) __VA_ARGS__)

--- a/include/message_builders.h
+++ b/include/message_builders.h
@@ -22,7 +22,7 @@ class VehicleActionBuilder {
    * @brief Get the map of builders for direct access
    * @return Reference to the builders map
    */
-  static const std::unordered_map<pb_size_t, BuilderFunction> &get_builders() { return BUILDERS; }
+  static const std::unordered_map<pb_size_t, BuilderFunction> &get_builders();
 
  private:
   // Builder functions for different action types
@@ -56,8 +56,7 @@ class VehicleActionBuilder {
   static int build_vehicle_control_schedule_software_update(CarServer_VehicleAction &action, const void *data);
   static int build_set_cabin_overheat_protection(CarServer_VehicleAction &action, const void *data);
 
-  // Map of action types to their builder functions
-  static const std::unordered_map<pb_size_t, BuilderFunction> BUILDERS;
+  // Map of action types to their builder functions - initialized lazily via get_builders()
 
   // Helper functions
   static int validate_input_parameters(const pb_byte_t *output_buffer, const size_t *output_length);

--- a/include/vehicle.h
+++ b/include/vehicle.h
@@ -20,51 +20,51 @@ namespace TeslaBLE {
 class Client;
 
 enum class SleepState {
-  Unknown,
-  Asleep,
-  Awake,
+  UNKNOWN,
+  ASLEEP,
+  AWAKE,
 };
 
 enum class WakePolicy {
-  NoWakeSkip,
-  NoWakeFail,
-  WakeIfNeeded,
+  NO_WAKE_SKIP,
+  NO_WAKE_FAIL,
+  WAKE_IF_NEEDED,
 };
 
 enum class OperationPhase {
-  Queued,
-  EnsuringVcsecSession,
-  EnsuringAwake,
-  EnsuringInfotainmentSession,
-  SendingRequest,
-  AwaitingResponse,
-  Terminal,
+  QUEUED,
+  ENSURING_VCSEC_SESSION,
+  ENSURING_AWAKE,
+  ENSURING_INFOTAINMENT_SESSION,
+  SENDING_REQUEST,
+  AWAITING_RESPONSE,
+  TERMINAL,
 };
 
 enum class OperationOutcome {
-  Success,
-  Skipped,
-  Failed,
+  SUCCESS,
+  SKIPPED,
+  FAILED,
 };
 
 enum class OperationTerminalReason {
-  None,
-  VehicleAsleep,
+  NONE,
+  VEHICLE_ASLEEP,
 };
 
 class OperationResult {
  public:
-  static OperationResult success(OperationTerminalReason reason = OperationTerminalReason::None) {
-    return OperationResult(OperationOutcome::Success, reason, nullptr);
+  static OperationResult success(OperationTerminalReason reason = OperationTerminalReason::NONE) {
+    return OperationResult(OperationOutcome::SUCCESS, reason, nullptr);
   }
 
   static OperationResult skipped(OperationTerminalReason reason) {
-    return OperationResult(OperationOutcome::Skipped, reason, nullptr);
+    return OperationResult(OperationOutcome::SKIPPED, reason, nullptr);
   }
 
   static OperationResult failure(std::unique_ptr<CommandError> error,
-                                 OperationTerminalReason reason = OperationTerminalReason::None) {
-    return OperationResult(OperationOutcome::Failed, reason, std::move(error));
+                                 OperationTerminalReason reason = OperationTerminalReason::NONE) {
+    return OperationResult(OperationOutcome::FAILED, reason, std::move(error));
   }
 
   OperationResult(OperationResult &&) = default;
@@ -75,10 +75,10 @@ class OperationResult {
 
   OperationOutcome outcome() const { return outcome_; }
   OperationTerminalReason reason() const { return reason_; }
-  bool is_success() const { return outcome_ == OperationOutcome::Success; }
-  bool is_skipped() const { return outcome_ == OperationOutcome::Skipped; }
-  bool is_failure() const { return outcome_ == OperationOutcome::Failed; }
-  bool compatible_success() const { return outcome_ != OperationOutcome::Failed; }
+  bool is_success() const { return outcome_ == OperationOutcome::SUCCESS; }
+  bool is_skipped() const { return outcome_ == OperationOutcome::SKIPPED; }
+  bool is_failure() const { return outcome_ == OperationOutcome::FAILED; }
+  bool compatible_success() const { return outcome_ != OperationOutcome::FAILED; }
   const CommandError *error() const { return error_.get(); }
   std::unique_ptr<CommandError> release_error() { return std::move(error_); }
 
@@ -115,12 +115,12 @@ struct Command {
   std::function<int(Client *, uint8_t *, size_t *)> builder;
   OperationResultCallback on_complete;
   OperationPhaseCallback on_phase_change;
-  WakePolicy wake_policy = WakePolicy::WakeIfNeeded;
+  WakePolicy wake_policy = WakePolicy::WAKE_IF_NEEDED;
 
   CommandState state = CommandState::IDLE;
-  OperationPhase phase = OperationPhase::Queued;
-  OperationOutcome outcome = OperationOutcome::Success;
-  OperationTerminalReason terminal_reason = OperationTerminalReason::None;
+  OperationPhase phase = OperationPhase::QUEUED;
+  OperationOutcome outcome = OperationOutcome::SUCCESS;
+  OperationTerminalReason terminal_reason = OperationTerminalReason::NONE;
   std::chrono::steady_clock::time_point started_at;
   std::chrono::steady_clock::time_point phase_started_at;
   std::chrono::steady_clock::time_point last_tx_at;
@@ -137,7 +137,7 @@ struct Command {
   UniversalMessage_Domain current_auth_domain;
 
   Command(UniversalMessage_Domain d, std::string n, std::function<int(Client *, uint8_t *, size_t *)> b,
-          OperationResultCallback cb = nullptr, WakePolicy wake = WakePolicy::WakeIfNeeded,
+          OperationResultCallback cb = nullptr, WakePolicy wake = WakePolicy::WAKE_IF_NEEDED,
           OperationPhaseCallback phase_cb = nullptr)
       : domain(d),
         name(std::move(n)),
@@ -162,7 +162,7 @@ class Vehicle {
 
   void on_rx_data(const std::vector<uint8_t> &data);
 
-  // Legacy overloads: bool requires_wake maps to WakePolicy::NoWakeSkip (false) or WakeIfNeeded (true).
+  // Legacy overloads: bool requires_wake maps to WakePolicy::NO_WAKE_SKIP (false) or WakeIfNeeded (true).
   // The rich-error callback receives nullptr for both success and skipped outcomes; to distinguish
   // them use send_command_result() with OperationResultCallback instead.
   void send_command(UniversalMessage_Domain domain, const std::string &name,
@@ -182,7 +182,7 @@ class Vehicle {
   void send_command_result(UniversalMessage_Domain domain, const std::string &name,
                            std::function<int(Client *, uint8_t *, size_t *)> builder,
                            Command::OperationResultCallback on_complete,
-                           WakePolicy wake_policy = WakePolicy::WakeIfNeeded,
+                           WakePolicy wake_policy = WakePolicy::WAKE_IF_NEEDED,
                            Command::OperationPhaseCallback on_phase_change = nullptr);
 
   void set_vehicle_status_callback(std::function<void(const VCSEC_VehicleStatus &)> cb) {
@@ -256,7 +256,7 @@ class Vehicle {
   bool is_connected() const { return is_connected_; }
   void set_connected(bool connected);
 
-  void set_awake(bool awake) { sleep_state_ = awake ? SleepState::Awake : SleepState::Asleep; }
+  void set_awake(bool awake) { sleep_state_ = awake ? SleepState::AWAKE : SleepState::ASLEEP; }
   void set_sleep_state(SleepState state) { sleep_state_ = state; }
   SleepState sleep_state() const { return sleep_state_; }
 
@@ -304,7 +304,7 @@ class Vehicle {
   std::function<void(const CarServer_ClosuresState &)> closures_state_callback_;
 
   bool is_connected_ = false;
-  SleepState sleep_state_ = SleepState::Unknown;
+  SleepState sleep_state_ = SleepState::UNKNOWN;
   bool recovery_attempted_ = false;
 
   static constexpr size_t FRAME_HEADER_SIZE = 2;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -272,7 +272,8 @@ int Client::parse_universal_message(pb_byte_t *input_buffer, size_t input_buffer
                                     UniversalMessage_RoutableMessage *output) {
   // Validate input parameters
   if (input_buffer == nullptr || output == nullptr || input_buffer_length == 0) {
-    LOG_ERROR("Invalid parameters: input_buffer=%p, output=%p, length=%zu", input_buffer, output, input_buffer_length);
+    LOG_ERROR("Invalid parameters: input_buffer=%p, output=%p, length=%zu", (void *) input_buffer, (void *) output,
+              input_buffer_length);
     return TeslaBLE_Status_E_ERROR_INVALID_PARAMS;
   }
 
@@ -306,7 +307,7 @@ int Client::parse_payload_session_info(UniversalMessage_RoutableMessage_session_
                                        Signatures_SessionInfo *output) {
   // Validate input parameters
   if (input_buffer == nullptr || output == nullptr) {
-    LOG_ERROR("Invalid parameters: input_buffer=%p, output=%p", input_buffer, output);
+    LOG_ERROR("Invalid parameters: input_buffer=%p, output=%p", (void *) input_buffer, (void *) output);
     return TeslaBLE_Status_E_ERROR_INVALID_PARAMS;
   }
 

--- a/src/logging_bridge.cpp
+++ b/src/logging_bridge.cpp
@@ -12,6 +12,7 @@ void set_log_callback(LogCallback callback) { g_log_callback = callback; }
 
 LogCallback get_log_callback() { return g_log_callback; }
 
+// NOLINTNEXTLINE(modernize-avoid-variadic-functions)
 void log_internal(LogLevel level, const char *tag, int line, const char *format, ...) {
   (void) line;  // Line number available for future use
 

--- a/src/message_builders.cpp
+++ b/src/message_builders.cpp
@@ -49,40 +49,42 @@ template<typename T> const T *require_data(const void *data, const char *message
 }
 }  // namespace
 
-// Initialize the static builder map
-const std::unordered_map<pb_size_t, VehicleActionBuilder::BuilderFunction> VehicleActionBuilder::BUILDERS = {
-    {CarServer_VehicleAction_chargingSetLimitAction_tag, build_charging_set_limit},
-    {CarServer_VehicleAction_chargingStartStopAction_tag, build_charging_start_stop},
-    {CarServer_VehicleAction_setChargingAmpsAction_tag, build_set_charging_amps},
-    {CarServer_VehicleAction_chargePortDoorOpen_tag, build_charge_port_door_open},
-    {CarServer_VehicleAction_chargePortDoorClose_tag, build_charge_port_door_close},
-    {CarServer_VehicleAction_scheduledChargingAction_tag, build_scheduled_charging},
-    {CarServer_VehicleAction_hvacAutoAction_tag, build_hvac_auto_action},
-    {CarServer_VehicleAction_hvacSteeringWheelHeaterAction_tag, build_hvac_steering_wheel_heater},
-    {CarServer_VehicleAction_vehicleControlFlashLightsAction_tag, build_vehicle_control_flash_lights},
-    {CarServer_VehicleAction_vehicleControlHonkHornAction_tag, build_vehicle_control_honk_horn},
-    {CarServer_VehicleAction_vehicleControlSetSentryModeAction_tag, build_vehicle_control_set_sentry_mode},
-    {CarServer_VehicleAction_vehicleControlCancelSoftwareUpdateAction_tag,
-     build_vehicle_control_cancel_software_update},
-    {CarServer_VehicleAction_vehicleControlResetValetPinAction_tag, build_vehicle_control_reset_valet_pin},
-    {CarServer_VehicleAction_vehicleControlResetPinToDriveAction_tag, build_vehicle_control_reset_pin_to_drive},
-    {CarServer_VehicleAction_drivingClearSpeedLimitPinAdminAction_tag, build_driving_clear_speed_limit_pin_admin},
-    {CarServer_VehicleAction_vehicleControlResetPinToDriveAdminAction_tag,
-     build_vehicle_control_reset_pin_to_drive_admin},
-    {CarServer_VehicleAction_mediaPlayAction_tag, build_media_play_action},
-    {CarServer_VehicleAction_mediaNextFavorite_tag, build_media_next_favorite},
-    {CarServer_VehicleAction_mediaPreviousFavorite_tag, build_media_previous_favorite},
-    {CarServer_VehicleAction_mediaNextTrack_tag, build_media_next_track},
-    {CarServer_VehicleAction_mediaPreviousTrack_tag, build_media_previous_track},
-    {CarServer_VehicleAction_ping_tag, build_ping_action},
-    {CarServer_VehicleAction_vehicleControlWindowAction_tag, build_vehicle_control_window_action},
-    {CarServer_VehicleAction_hvacSetPreconditioningMaxAction_tag, build_hvac_set_preconditioning_max},
-    {CarServer_VehicleAction_hvacTemperatureAdjustmentAction_tag, build_hvac_temperature_adjustment},
-    {CarServer_VehicleAction_hvacClimateKeeperAction_tag, build_hvac_climate_keeper},
-    {CarServer_VehicleAction_hvacBioweaponModeAction_tag, build_hvac_bioweapon_mode},
-    {CarServer_VehicleAction_vehicleControlScheduleSoftwareUpdateAction_tag,
-     build_vehicle_control_schedule_software_update},
-    {CarServer_VehicleAction_setCabinOverheatProtectionAction_tag, build_set_cabin_overheat_protection}};
+const std::unordered_map<pb_size_t, VehicleActionBuilder::BuilderFunction> &VehicleActionBuilder::get_builders() {
+  static const std::unordered_map<pb_size_t, BuilderFunction> BUILDERS = {
+      {CarServer_VehicleAction_chargingSetLimitAction_tag, build_charging_set_limit},
+      {CarServer_VehicleAction_chargingStartStopAction_tag, build_charging_start_stop},
+      {CarServer_VehicleAction_setChargingAmpsAction_tag, build_set_charging_amps},
+      {CarServer_VehicleAction_chargePortDoorOpen_tag, build_charge_port_door_open},
+      {CarServer_VehicleAction_chargePortDoorClose_tag, build_charge_port_door_close},
+      {CarServer_VehicleAction_scheduledChargingAction_tag, build_scheduled_charging},
+      {CarServer_VehicleAction_hvacAutoAction_tag, build_hvac_auto_action},
+      {CarServer_VehicleAction_hvacSteeringWheelHeaterAction_tag, build_hvac_steering_wheel_heater},
+      {CarServer_VehicleAction_vehicleControlFlashLightsAction_tag, build_vehicle_control_flash_lights},
+      {CarServer_VehicleAction_vehicleControlHonkHornAction_tag, build_vehicle_control_honk_horn},
+      {CarServer_VehicleAction_vehicleControlSetSentryModeAction_tag, build_vehicle_control_set_sentry_mode},
+      {CarServer_VehicleAction_vehicleControlCancelSoftwareUpdateAction_tag,
+       build_vehicle_control_cancel_software_update},
+      {CarServer_VehicleAction_vehicleControlResetValetPinAction_tag, build_vehicle_control_reset_valet_pin},
+      {CarServer_VehicleAction_vehicleControlResetPinToDriveAction_tag, build_vehicle_control_reset_pin_to_drive},
+      {CarServer_VehicleAction_drivingClearSpeedLimitPinAdminAction_tag, build_driving_clear_speed_limit_pin_admin},
+      {CarServer_VehicleAction_vehicleControlResetPinToDriveAdminAction_tag,
+       build_vehicle_control_reset_pin_to_drive_admin},
+      {CarServer_VehicleAction_mediaPlayAction_tag, build_media_play_action},
+      {CarServer_VehicleAction_mediaNextFavorite_tag, build_media_next_favorite},
+      {CarServer_VehicleAction_mediaPreviousFavorite_tag, build_media_previous_favorite},
+      {CarServer_VehicleAction_mediaNextTrack_tag, build_media_next_track},
+      {CarServer_VehicleAction_mediaPreviousTrack_tag, build_media_previous_track},
+      {CarServer_VehicleAction_ping_tag, build_ping_action},
+      {CarServer_VehicleAction_vehicleControlWindowAction_tag, build_vehicle_control_window_action},
+      {CarServer_VehicleAction_hvacSetPreconditioningMaxAction_tag, build_hvac_set_preconditioning_max},
+      {CarServer_VehicleAction_hvacTemperatureAdjustmentAction_tag, build_hvac_temperature_adjustment},
+      {CarServer_VehicleAction_hvacClimateKeeperAction_tag, build_hvac_climate_keeper},
+      {CarServer_VehicleAction_hvacBioweaponModeAction_tag, build_hvac_bioweapon_mode},
+      {CarServer_VehicleAction_vehicleControlScheduleSoftwareUpdateAction_tag,
+       build_vehicle_control_schedule_software_update},
+      {CarServer_VehicleAction_setCabinOverheatProtectionAction_tag, build_set_cabin_overheat_protection}};
+  return BUILDERS;
+}
 
 // Builder implementations
 int VehicleActionBuilder::build_charging_set_limit(CarServer_VehicleAction &action, const void *data) {

--- a/src/peer.cpp
+++ b/src/peer.cpp
@@ -175,10 +175,10 @@ int Peer::load_tesla_key(const uint8_t *public_key_buffer, size_t public_key_siz
   LOG_DEBUG("Tesla key loaded and session established successfully");
   LOG_VERBOSE(
       "Session key (first 16 bytes): %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
-      shared_secret_sha1_[0], shared_secret_sha1_[1], shared_secret_sha1_[2], shared_secret_sha1_[3],
-      shared_secret_sha1_[4], shared_secret_sha1_[5], shared_secret_sha1_[6], shared_secret_sha1_[7],
-      shared_secret_sha1_[8], shared_secret_sha1_[9], shared_secret_sha1_[10], shared_secret_sha1_[11],
-      shared_secret_sha1_[12], shared_secret_sha1_[13], shared_secret_sha1_[14], shared_secret_sha1_[15]);
+      shared_secret_sha1_.at(0), shared_secret_sha1_.at(1), shared_secret_sha1_.at(2), shared_secret_sha1_.at(3),
+      shared_secret_sha1_.at(4), shared_secret_sha1_.at(5), shared_secret_sha1_.at(6), shared_secret_sha1_.at(7),
+      shared_secret_sha1_.at(8), shared_secret_sha1_.at(9), shared_secret_sha1_.at(10), shared_secret_sha1_.at(11),
+      shared_secret_sha1_.at(12), shared_secret_sha1_.at(13), shared_secret_sha1_.at(14), shared_secret_sha1_.at(15));
 
   return TeslaBLE_Status_E_OK;
 }

--- a/src/tb_logging.cpp
+++ b/src/tb_logging.cpp
@@ -595,7 +595,7 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
   }
 
   if (charge_state.which_optional_battery_level) {
-    LOG_DEBUG("Battery Level: %ld%%", charge_state.optional_battery_level.battery_level);
+    LOG_DEBUG("Battery Level: %d%%", charge_state.optional_battery_level.battery_level);
   }
 
   if (charge_state.which_optional_battery_range) {
@@ -603,39 +603,39 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
   }
 
   if (charge_state.which_optional_charger_power) {
-    LOG_DEBUG("Charger Power: %ld", charge_state.optional_charger_power.charger_power);
+    LOG_DEBUG("Charger Power: %d", charge_state.optional_charger_power.charger_power);
   }
 
   if (charge_state.which_optional_charge_rate_mph) {
-    LOG_DEBUG("Charge Rate: %ld mph", charge_state.optional_charge_rate_mph.charge_rate_mph);
+    LOG_DEBUG("Charge Rate: %d mph", charge_state.optional_charge_rate_mph.charge_rate_mph);
   }
 
   if (charge_state.which_optional_minutes_to_full_charge) {
-    LOG_DEBUG("Minutes to Full: %ld", charge_state.optional_minutes_to_full_charge.minutes_to_full_charge);
+    LOG_DEBUG("Minutes to Full: %d", charge_state.optional_minutes_to_full_charge.minutes_to_full_charge);
   }
 
   if (charge_state.which_optional_minutes_to_charge_limit) {
-    LOG_DEBUG("Minutes to Charge Limit: %ld", charge_state.optional_minutes_to_charge_limit.minutes_to_charge_limit);
+    LOG_DEBUG("Minutes to Charge Limit: %d", charge_state.optional_minutes_to_charge_limit.minutes_to_charge_limit);
   }
 
   if (charge_state.which_optional_charger_voltage) {
-    LOG_DEBUG("Charger Voltage: %ld", charge_state.optional_charger_voltage.charger_voltage);
+    LOG_DEBUG("Charger Voltage: %d", charge_state.optional_charger_voltage.charger_voltage);
   }
 
   if (charge_state.which_optional_charger_pilot_current) {
-    LOG_DEBUG("Charger Pilot Current: %ld", charge_state.optional_charger_pilot_current.charger_pilot_current);
+    LOG_DEBUG("Charger Pilot Current: %d", charge_state.optional_charger_pilot_current.charger_pilot_current);
   }
 
   if (charge_state.which_optional_charger_actual_current) {
-    LOG_DEBUG("Charger Actual Current: %ld", charge_state.optional_charger_actual_current.charger_actual_current);
+    LOG_DEBUG("Charger Actual Current: %d", charge_state.optional_charger_actual_current.charger_actual_current);
   }
 
   if (charge_state.which_optional_charge_current_request) {
-    LOG_DEBUG("Charge Current Request: %ld", charge_state.optional_charge_current_request.charge_current_request);
+    LOG_DEBUG("Charge Current Request: %d", charge_state.optional_charge_current_request.charge_current_request);
   }
 
   if (charge_state.which_optional_charge_current_request_max) {
-    LOG_DEBUG("Charge Current Request Max: %ld",
+    LOG_DEBUG("Charge Current Request Max: %d",
               charge_state.optional_charge_current_request_max.charge_current_request_max);
   }
 
@@ -665,7 +665,7 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
   }
 
   if (charge_state.which_optional_charger_phases) {
-    LOG_DEBUG("Charger Phases: %ld", charge_state.optional_charger_phases.charger_phases);
+    LOG_DEBUG("Charger Phases: %d", charge_state.optional_charger_phases.charger_phases);
   }
 
   if (charge_state.which_optional_charge_port_color) {
@@ -682,7 +682,7 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
       LOG_DEBUG("Charge On Solar State: %d", charge_state.managed_charging_state.charge_on_solar_state.which_state);
     }
     if (charge_state.managed_charging_state.which_optional_minutes_to_lower_limit) {
-      LOG_DEBUG("Managed Charging Minutes to Lower Limit: %ld",
+      LOG_DEBUG("Managed Charging Minutes to Lower Limit: %d",
                 charge_state.managed_charging_state.optional_minutes_to_lower_limit.minutes_to_lower_limit);
     }
   }
@@ -796,7 +796,7 @@ void log_carserver_response(const char *tag, const CarServer_Response *msg) {
       break;
     case CarServer_Response_ping_tag:
       LOG_DEBUG("  ping:");
-      LOG_DEBUG("    ping: %ld", msg->response_msg.ping.ping_id);
+      LOG_DEBUG("    ping: %d", msg->response_msg.ping.ping_id);
       break;
     default:
       // do nothing

--- a/src/tb_utils.cpp
+++ b/src/tb_utils.cpp
@@ -29,12 +29,13 @@ TeslaBLE_Status_E pb_encode_fields(pb_byte_t *output_buffer, size_t *output_leng
                                    const void *src_struct) {
   // Validate input parameters
   if (!output_buffer || !output_length || !fields || !src_struct) {
-    LOG_ERROR("pb_encode: Invalid parameters (buffer=%p, length=%p, fields=%p, struct=%p)", output_buffer,
-              output_length, fields, src_struct);
+    LOG_ERROR("pb_encode: Invalid parameters (buffer=%p, length=%p, fields=%p, struct=%p)", (void *) output_buffer,
+              (void *) output_length, (void *) fields, src_struct);
     return TeslaBLE_Status_E_ERROR_PB_ENCODING;
   }
 
-  pb_ostream_t unsigned_message_size_stream = {nullptr, 0, 0, 0, nullptr};
+  pb_ostream_t unsigned_message_size_stream = {
+      .callback = nullptr, .state = nullptr, .max_size = 0, .bytes_written = 0, .errmsg = nullptr};
   bool status_encode_length = pb_encode(&unsigned_message_size_stream, fields, src_struct);
   if (!status_encode_length) {
     LOG_ERROR("pb_encode: Failed to get encoded message size (err: %s)", PB_GET_ERROR(&unsigned_message_size_stream));

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -25,7 +25,7 @@ namespace TeslaBLE {
 namespace {
 
 WakePolicy wake_policy_from_bool(bool requires_wake) {
-  return requires_wake ? WakePolicy::WakeIfNeeded : WakePolicy::NoWakeSkip;
+  return requires_wake ? WakePolicy::WAKE_IF_NEEDED : WakePolicy::NO_WAKE_SKIP;
 }
 
 std::unique_ptr<CommandError> build_carserver_action_error(const CarServer_ActionStatus &status) {
@@ -88,7 +88,7 @@ void TeslaBLE::Vehicle::set_connected(bool connected) {
       info_peer->reset();
     }
 
-    sleep_state_ = SleepState::Unknown;
+    sleep_state_ = SleepState::UNKNOWN;
 
     while (!command_queue_.empty()) {
       auto cmd = command_queue_.front();
@@ -278,12 +278,12 @@ void TeslaBLE::Vehicle::process_authenticating_command_(const std::shared_ptr<Co
     case UniversalMessage_Domain_DOMAIN_INFOTAINMENT:
       if (!is_domain_authenticated_(UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY)) {
         LOG_DEBUG("VCSEC auth required before Infotainment auth");
-        set_command_phase_(command, OperationPhase::EnsuringVcsecSession);
+        set_command_phase_(command, OperationPhase::ENSURING_VCSEC_SESSION);
         command->current_auth_domain = UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY;
         initiate_auth_for_domain_(command, UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY,
                                   CommandState::AUTH_RESPONSE_WAITING, "VCSEC");
       } else {
-        set_command_phase_(command, OperationPhase::EnsuringInfotainmentSession);
+        set_command_phase_(command, OperationPhase::ENSURING_INFOTAINMENT_SESSION);
         initiate_auth_for_domain_(command, UniversalMessage_Domain_DOMAIN_INFOTAINMENT,
                                   CommandState::AUTH_RESPONSE_WAITING, "Infotainment");
       }
@@ -327,7 +327,7 @@ void TeslaBLE::Vehicle::handle_auth_timeout_common_(const std::shared_ptr<Comman
   auto total_duration = std::chrono::duration_cast<std::chrono::seconds>(now - command->started_at);
   int attempt_level = std::min(command->retry_count / 2, 3);
   static constexpr std::array<int, 4> TIMEOUT_THRESHOLDS = {30, 60, 120, 300};
-  if (total_duration > std::chrono::seconds(TIMEOUT_THRESHOLDS[attempt_level])) {
+  if (total_duration > std::chrono::seconds(TIMEOUT_THRESHOLDS.at(attempt_level))) {
     LOG_ERROR("Connection validation failed: %s auth stuck for %lld seconds (level %d, retry %d)", domain_name.c_str(),
               (long long) total_duration.count(), attempt_level, command->retry_count);
     reset_all_sessions_and_connection_();
@@ -368,7 +368,7 @@ void TeslaBLE::Vehicle::initiate_auth_for_domain_(const std::shared_ptr<Command>
                                                   const std::string &domain_name) {
   if (is_domain_authenticated_(domain)) {
     if (command->domain == domain) {
-      set_command_phase_(command, OperationPhase::SendingRequest);
+      set_command_phase_(command, OperationPhase::SENDING_REQUEST);
       command->state = CommandState::READY;
     } else if (domain == UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY &&
                command->domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
@@ -395,31 +395,31 @@ void TeslaBLE::Vehicle::initiate_auth_for_domain_(const std::shared_ptr<Command>
 
 void TeslaBLE::Vehicle::initiate_vcsec_auth_(const std::shared_ptr<Command> &command) {
   command->current_auth_domain = UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY;
-  set_command_phase_(command, OperationPhase::EnsuringVcsecSession);
+  set_command_phase_(command, OperationPhase::ENSURING_VCSEC_SESSION);
   initiate_auth_for_domain_(command, UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY,
                             CommandState::AUTH_RESPONSE_WAITING, "VCSEC");
 }
 
 void TeslaBLE::Vehicle::initiate_infotainment_auth_(const std::shared_ptr<Command> &command) {
-  set_command_phase_(command, OperationPhase::Queued);
+  set_command_phase_(command, OperationPhase::QUEUED);
 
   switch (command->wake_policy) {
-    case WakePolicy::NoWakeSkip:
+    case WakePolicy::NO_WAKE_SKIP:
       if (is_vehicle_observed_asleep_()) {
         LOG_DEBUG("Vehicle asleep, skipping command with NoWakeSkip: %s", command->name.c_str());
-        mark_command_skipped_(command, OperationTerminalReason::VehicleAsleep);
+        mark_command_skipped_(command, OperationTerminalReason::VEHICLE_ASLEEP);
         return;
       }
       break;
-    case WakePolicy::NoWakeFail:
+    case WakePolicy::NO_WAKE_FAIL:
       if (is_vehicle_observed_asleep_()) {
         LOG_DEBUG("Vehicle asleep, failing command with NoWakeFail: %s", command->name.c_str());
         mark_command_failed_(command, CommandError::build_failed("vehicle asleep"),
-                             OperationTerminalReason::VehicleAsleep);
+                             OperationTerminalReason::VEHICLE_ASLEEP);
         return;
       }
       break;
-    case WakePolicy::WakeIfNeeded:
+    case WakePolicy::WAKE_IF_NEEDED:
       break;
   }
 
@@ -429,21 +429,21 @@ void TeslaBLE::Vehicle::initiate_infotainment_auth_(const std::shared_ptr<Comman
 void TeslaBLE::Vehicle::advance_infotainment_prerequisites_(const std::shared_ptr<Command> &command) {
   if (!is_domain_authenticated_(UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY)) {
     LOG_DEBUG("VCSEC auth required before Infotainment auth");
-    set_command_phase_(command, OperationPhase::EnsuringVcsecSession);
+    set_command_phase_(command, OperationPhase::ENSURING_VCSEC_SESSION);
     initiate_vcsec_auth_(command);
     return;
   }
 
-  if (!is_vehicle_observed_awake_() && command->wake_policy == WakePolicy::WakeIfNeeded) {
+  if (!is_vehicle_observed_awake_() && command->wake_policy == WakePolicy::WAKE_IF_NEEDED) {
     LOG_DEBUG("Vehicle is not awake and wake policy requires wake, initiating wake sequence");
-    set_command_phase_(command, OperationPhase::EnsuringAwake);
+    set_command_phase_(command, OperationPhase::ENSURING_AWAKE);
     command->current_auth_domain = UniversalMessage_Domain_DOMAIN_BROADCAST;
     command->state = CommandState::AUTHENTICATING;
     command->last_tx_at = std::chrono::steady_clock::time_point();
     return;
   }
 
-  set_command_phase_(command, OperationPhase::EnsuringInfotainmentSession);
+  set_command_phase_(command, OperationPhase::ENSURING_INFOTAINMENT_SESSION);
   initiate_auth_for_domain_(command, UniversalMessage_Domain_DOMAIN_INFOTAINMENT, CommandState::AUTH_RESPONSE_WAITING,
                             "Infotainment");
 }
@@ -453,7 +453,7 @@ void TeslaBLE::Vehicle::resume_command_after_prerequisite_(const std::shared_ptr
 }
 
 void TeslaBLE::Vehicle::initiate_wake_sequence_(const std::shared_ptr<Command> &command) {
-  set_command_phase_(command, OperationPhase::EnsuringAwake);
+  set_command_phase_(command, OperationPhase::ENSURING_AWAKE);
   uint8_t buffer[256];
   size_t len = 256;
   if (client_->build_vcsec_action_message(VCSEC_RKEAction_E_RKE_ACTION_WAKE_VEHICLE, buffer, &len) == 0) {
@@ -510,7 +510,7 @@ void TeslaBLE::Vehicle::retry_command(const std::shared_ptr<Command> &command) {
             static_cast<long long>(backoff_delay.count()), command->name.c_str());
   command->last_tx_at = std::chrono::steady_clock::now() - backoff_delay + std::chrono::milliseconds(100);
 
-  set_command_phase_(command, OperationPhase::Queued);
+  set_command_phase_(command, OperationPhase::QUEUED);
   switch (command->state) {
     case CommandState::WAITING_FOR_RESPONSE:
       command->state = CommandState::READY;
@@ -523,7 +523,7 @@ void TeslaBLE::Vehicle::retry_command(const std::shared_ptr<Command> &command) {
 }
 
 void TeslaBLE::Vehicle::process_ready_command_(const std::shared_ptr<Command> &command) {
-  set_command_phase_(command, OperationPhase::SendingRequest);
+  set_command_phase_(command, OperationPhase::SENDING_REQUEST);
   uint8_t buffer[256];
   size_t len = 256;
   if (command->builder(client_.get(), buffer, &len) == 0) {
@@ -531,7 +531,7 @@ void TeslaBLE::Vehicle::process_ready_command_(const std::shared_ptr<Command> &c
     if (ble_adapter_->write(data)) {
       LOG_DEBUG("Sent command: %s (%zu bytes)", command->name.c_str(), data.size());
       command->state = CommandState::WAITING_FOR_RESPONSE;
-      set_command_phase_(command, OperationPhase::AwaitingResponse);
+      set_command_phase_(command, OperationPhase::AWAITING_RESPONSE);
       command->last_tx_at = std::chrono::steady_clock::now();
     } else {
       LOG_ERROR("Failed to write command data: %s", command->name.c_str());
@@ -567,7 +567,7 @@ void TeslaBLE::Vehicle::mark_command_failed_(const std::shared_ptr<Command> &com
 
 void TeslaBLE::Vehicle::mark_command_completed_(const std::shared_ptr<Command> &command) {
   command->state = CommandState::COMPLETED;
-  set_command_phase_(command, OperationPhase::Terminal);
+  set_command_phase_(command, OperationPhase::TERMINAL);
   auto now = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - command->started_at);
   LOG_INFO("[%s] Command completed successfully in %lld ms", command->name.c_str(), (long long) duration.count());
@@ -576,7 +576,7 @@ void TeslaBLE::Vehicle::mark_command_completed_(const std::shared_ptr<Command> &
 
 void TeslaBLE::Vehicle::mark_command_skipped_(const std::shared_ptr<Command> &command, OperationTerminalReason reason) {
   command->state = CommandState::COMPLETED;
-  set_command_phase_(command, OperationPhase::Terminal);
+  set_command_phase_(command, OperationPhase::TERMINAL);
   LOG_INFO("[%s] Command skipped (reason: %d)", command->name.c_str(), static_cast<int>(reason));
   finalize_command_(command, OperationResult::skipped(reason));
 }
@@ -600,9 +600,9 @@ void TeslaBLE::Vehicle::finalize_command_(const std::shared_ptr<Command> &comman
   }
 }
 
-bool Vehicle::is_vehicle_observed_awake_() const { return sleep_state_ == SleepState::Awake; }
+bool Vehicle::is_vehicle_observed_awake_() const { return sleep_state_ == SleepState::AWAKE; }
 
-bool Vehicle::is_vehicle_observed_asleep_() const { return sleep_state_ == SleepState::Asleep; }
+bool Vehicle::is_vehicle_observed_asleep_() const { return sleep_state_ == SleepState::ASLEEP; }
 
 bool Vehicle::is_domain_authenticated_(UniversalMessage_Domain domain) {
   auto *peer = client_->get_peer(domain);
@@ -630,7 +630,7 @@ bool Vehicle::is_message_complete() {
 int Vehicle::get_expected_message_length() {
   if (rx_buffer_.size() < FRAME_HEADER_SIZE)
     return 0;
-  return static_cast<int>((rx_buffer_[0] << 8) | rx_buffer_[1]) + FRAME_HEADER_SIZE;
+  return static_cast<int>((rx_buffer_.at(0) << 8) | rx_buffer_.at(1)) + FRAME_HEADER_SIZE;
 }
 
 void TeslaBLE::Vehicle::process_complete_message() {
@@ -880,8 +880,8 @@ void TeslaBLE::Vehicle::handle_vcsec_message_(const UniversalMessage_RoutableMes
       log_vehicle_status(TESLA_LOG_TAG, &vcsec_msg.sub_message.vehicleStatus);
       sleep_state_ = vcsec_msg.sub_message.vehicleStatus.vehicleSleepStatus !=
                              VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_ASLEEP
-                         ? SleepState::Awake
-                         : SleepState::Asleep;
+                         ? SleepState::AWAKE
+                         : SleepState::ASLEEP;
       if (vehicle_status_callback_) {
         vehicle_status_callback_(vcsec_msg.sub_message.vehicleStatus);
       }
@@ -970,7 +970,7 @@ void TeslaBLE::Vehicle::handle_authentication_response_(UniversalMessage_Domain 
       resume_command_after_prerequisite_(cmd);
       return;
     }
-    set_command_phase_(cmd, OperationPhase::SendingRequest);
+    set_command_phase_(cmd, OperationPhase::SENDING_REQUEST);
     cmd->state = CommandState::READY;
     return;
   }
@@ -1019,7 +1019,7 @@ bool Vehicle::attempt_buffer_recovery_(int &msg_len) {
 
   // Search for potential next valid message start
   for (size_t i = 1; i < rx_buffer_.size() - FRAME_HEADER_SIZE; i++) {
-    uint16_t potential_len = (rx_buffer_[i] << 8) | rx_buffer_[i + 1];
+    uint16_t potential_len = (rx_buffer_.at(i) << 8) | rx_buffer_.at(i + 1);
 
     // Valid length check: reasonable size and fits in buffer
     // Also check for corrupted length values (near max uint16)
@@ -1053,7 +1053,7 @@ void TeslaBLE::Vehicle::handle_vehicle_status_command_update_(const std::shared_
         if (cmd->domain == UniversalMessage_Domain_DOMAIN_INFOTAINMENT) {
           LOG_DEBUG("Transitioning infotainment command to auth state after wake");
           // Restart the step timeout budget now that wake succeeded and infotainment auth can begin.
-          set_command_phase_(cmd, OperationPhase::EnsuringInfotainmentSession);
+          set_command_phase_(cmd, OperationPhase::ENSURING_INFOTAINMENT_SESSION);
           cmd->current_auth_domain = UniversalMessage_Domain_DOMAIN_INFOTAINMENT;
           cmd->state = CommandState::AUTHENTICATING;
         } else {

--- a/tests/test_vehicle.cpp
+++ b/tests/test_vehicle.cpp
@@ -515,7 +515,7 @@ TEST_F(VehicleTest, InfotainmentPollWithForceWakeSendsData) {
 
 TEST_F(VehicleTest, InfotainmentPollCompletesOnResponse) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::AWAKE);
 
   bool callback_called = false;
   bool callback_success = false;
@@ -569,7 +569,7 @@ TEST_F(VehicleTest, InfotainmentPollCompletesOnResponse) {
 
 TEST_F(VehicleTest, InfotainmentActionFailureSurfacesPlainTextReason) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::AWAKE);
 
   bool callback_called = false;
   std::unique_ptr<CommandError> captured_error;
@@ -635,7 +635,7 @@ TEST_F(VehicleTest, InfotainmentPollSkippedWhenAsleepByDefault) {
   // Verify default behavior: vehicle starts in asleep state (no VCSEC status received)
   // and infotainment polls without force_wake should be skipped
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
 
   bool poll_callback_called = false;
   bool poll_success = false;
@@ -845,7 +845,7 @@ TEST_F(VehicleTest, InfotainmentPollWithoutForceWakeSkipsWhenAsleep) {
 
   // Send poll that doesn't require wake
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
   vehicle_->send_command_bool(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Infotainment Poll",
       [](Client *client, uint8_t *buff, size_t *len) {
@@ -1444,7 +1444,7 @@ TEST_F(VehicleTest, PairingBypassesAuthEvenWhenVcsecAuthIsFailing) {
 
 TEST_F(VehicleTest, NoWakeSkipSkipsWhenVehicleAsleep) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
 
   bool callback_called = false;
   bool callback_success = false;
@@ -1459,7 +1459,7 @@ TEST_F(VehicleTest, NoWakeSkipSkipsWhenVehicleAsleep) {
         callback_called = true;
         callback_success = success;
       },
-      TeslaBLE::WakePolicy::NoWakeSkip);
+      TeslaBLE::WakePolicy::NO_WAKE_SKIP);
 
   vehicle_->loop();
 
@@ -1471,7 +1471,7 @@ TEST_F(VehicleTest, NoWakeSkipSkipsWhenVehicleAsleep) {
 
 TEST_F(VehicleTest, NoWakeFailWhenVehicleAsleep) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
 
   bool callback_called = false;
   bool callback_success = true;
@@ -1486,7 +1486,7 @@ TEST_F(VehicleTest, NoWakeFailWhenVehicleAsleep) {
         callback_called = true;
         callback_success = success;
       },
-      TeslaBLE::WakePolicy::NoWakeFail);
+      TeslaBLE::WakePolicy::NO_WAKE_FAIL);
 
   vehicle_->loop();
 
@@ -1498,7 +1498,7 @@ TEST_F(VehicleTest, NoWakeFailWhenVehicleAsleep) {
 
 TEST_F(VehicleTest, WakeIfNeededProceedsWhenAwake) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::AWAKE);
 
   vehicle_->send_command_bool(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "WakeIfNeeded Poll",
@@ -1506,7 +1506,7 @@ TEST_F(VehicleTest, WakeIfNeededProceedsWhenAwake) {
         return client->build_car_server_get_vehicle_data_message(buff, len,
                                                                  CarServer_GetVehicleData_getChargeState_tag);
       },
-      nullptr, TeslaBLE::WakePolicy::WakeIfNeeded);
+      nullptr, TeslaBLE::WakePolicy::WAKE_IF_NEEDED);
 
   vehicle_->loop();
 
@@ -1516,7 +1516,7 @@ TEST_F(VehicleTest, WakeIfNeededProceedsWhenAwake) {
 
 TEST_F(VehicleTest, WakeIfNeededTriggersWakeWhenAsleep) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
 
   vehicle_->send_command_bool(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "WakeIfNeeded Asleep",
@@ -1524,7 +1524,7 @@ TEST_F(VehicleTest, WakeIfNeededTriggersWakeWhenAsleep) {
         return client->build_car_server_get_vehicle_data_message(buff, len,
                                                                  CarServer_GetVehicleData_getChargeState_tag);
       },
-      nullptr, TeslaBLE::WakePolicy::WakeIfNeeded);
+      nullptr, TeslaBLE::WakePolicy::WAKE_IF_NEEDED);
 
   vehicle_->loop();
 
@@ -1534,11 +1534,11 @@ TEST_F(VehicleTest, WakeIfNeededTriggersWakeWhenAsleep) {
 
 TEST_F(VehicleTest, WakePolicyRichOutcomeCallbackDistinguishesSkipped) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
 
   bool callback_called = false;
-  TeslaBLE::OperationOutcome captured_outcome = TeslaBLE::OperationOutcome::Failed;
-  TeslaBLE::OperationTerminalReason captured_reason = TeslaBLE::OperationTerminalReason::None;
+  TeslaBLE::OperationOutcome captured_outcome = TeslaBLE::OperationOutcome::FAILED;
+  TeslaBLE::OperationTerminalReason captured_reason = TeslaBLE::OperationTerminalReason::NONE;
 
   vehicle_->send_command_result(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Result Poll",
@@ -1551,21 +1551,21 @@ TEST_F(VehicleTest, WakePolicyRichOutcomeCallbackDistinguishesSkipped) {
         captured_outcome = result.outcome();
         captured_reason = result.reason();
       },
-      TeslaBLE::WakePolicy::NoWakeSkip);
+      TeslaBLE::WakePolicy::NO_WAKE_SKIP);
 
   vehicle_->loop();
 
   ASSERT_TRUE(callback_called) << "Rich callback should be invoked";
-  EXPECT_EQ(captured_outcome, TeslaBLE::OperationOutcome::Skipped);
-  EXPECT_EQ(captured_reason, TeslaBLE::OperationTerminalReason::VehicleAsleep);
+  EXPECT_EQ(captured_outcome, TeslaBLE::OperationOutcome::SKIPPED);
+  EXPECT_EQ(captured_reason, TeslaBLE::OperationTerminalReason::VEHICLE_ASLEEP);
 }
 
 TEST_F(VehicleTest, WakePolicyRichOutcomeCallbackDistinguishesFailed) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
 
   bool callback_called = false;
-  TeslaBLE::OperationOutcome captured_outcome = TeslaBLE::OperationOutcome::Success;
+  TeslaBLE::OperationOutcome captured_outcome = TeslaBLE::OperationOutcome::SUCCESS;
 
   vehicle_->send_command_result(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Fail Poll",
@@ -1577,12 +1577,12 @@ TEST_F(VehicleTest, WakePolicyRichOutcomeCallbackDistinguishesFailed) {
         callback_called = true;
         captured_outcome = result.outcome();
       },
-      TeslaBLE::WakePolicy::NoWakeFail);
+      TeslaBLE::WakePolicy::NO_WAKE_FAIL);
 
   vehicle_->loop();
 
   ASSERT_TRUE(callback_called) << "Rich callback should be invoked";
-  EXPECT_EQ(captured_outcome, TeslaBLE::OperationOutcome::Failed);
+  EXPECT_EQ(captured_outcome, TeslaBLE::OperationOutcome::FAILED);
 }
 
 // ============================================================================
@@ -1622,7 +1622,7 @@ TEST_F(VehicleTest, WakePhaseTimeoutDoesNotConsumeFinalResponseBudget) {
 
   // Command should be in AUTH_RESPONSE_WAITING for the wake phase
   EXPECT_EQ(command->state, TeslaBLE::CommandState::AUTH_RESPONSE_WAITING);
-  EXPECT_EQ(command->phase, TeslaBLE::OperationPhase::EnsuringAwake);
+  EXPECT_EQ(command->phase, TeslaBLE::OperationPhase::ENSURING_AWAKE);
 
   // Advance time to exhaust wake-phase timeout but leave total command budget untouched.
   // Wake timeout is measured from last_tx_at (when wake command was actually sent).
@@ -1638,7 +1638,7 @@ TEST_F(VehicleTest, WakePhaseTimeoutDoesNotConsumeFinalResponseBudget) {
 
 TEST_F(VehicleTest, AuthPhaseTimeoutIndependentFromFinalResponseTimeout) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::AWAKE);
 
   vehicle_->send_command_bool(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Auth Timeout Poll",
@@ -1659,7 +1659,7 @@ TEST_F(VehicleTest, AuthPhaseTimeoutIndependentFromFinalResponseTimeout) {
   ASSERT_FALSE(command_queue.empty());
   auto command = command_queue.front();
 
-  EXPECT_EQ(command->phase, TeslaBLE::OperationPhase::EnsuringVcsecSession);
+  EXPECT_EQ(command->phase, TeslaBLE::OperationPhase::ENSURING_VCSEC_SESSION);
 
   // Advance time past auth timeout
   command->phase_started_at =
@@ -1677,10 +1677,10 @@ TEST_F(VehicleTest, AuthPhaseTimeoutIndependentFromFinalResponseTimeout) {
 
 TEST_F(VehicleTest, WrapperCanObserveSkippedOutcomeWithoutInspectingInternals) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
 
-  TeslaBLE::OperationOutcome outcome = TeslaBLE::OperationOutcome::Failed;
-  TeslaBLE::OperationTerminalReason reason = TeslaBLE::OperationTerminalReason::None;
+  TeslaBLE::OperationOutcome outcome = TeslaBLE::OperationOutcome::FAILED;
+  TeslaBLE::OperationTerminalReason reason = TeslaBLE::OperationTerminalReason::NONE;
   const TeslaBLE::CommandError *err = nullptr;
 
   vehicle_->send_command_result(
@@ -1694,21 +1694,21 @@ TEST_F(VehicleTest, WrapperCanObserveSkippedOutcomeWithoutInspectingInternals) {
         reason = result.reason();
         err = result.error();
       },
-      TeslaBLE::WakePolicy::NoWakeSkip);
+      TeslaBLE::WakePolicy::NO_WAKE_SKIP);
 
   vehicle_->loop();
 
-  EXPECT_EQ(outcome, TeslaBLE::OperationOutcome::Skipped);
-  EXPECT_EQ(reason, TeslaBLE::OperationTerminalReason::VehicleAsleep);
+  EXPECT_EQ(outcome, TeslaBLE::OperationOutcome::SKIPPED);
+  EXPECT_EQ(reason, TeslaBLE::OperationTerminalReason::VEHICLE_ASLEEP);
   EXPECT_EQ(err, nullptr) << "Skipped operations should not carry an error";
 }
 
 TEST_F(VehicleTest, WrapperCanObservePhaseTransitions) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Awake);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::AWAKE);
 
   std::vector<TeslaBLE::OperationPhase> phases;
-  TeslaBLE::OperationOutcome outcome = TeslaBLE::OperationOutcome::Failed;
+  TeslaBLE::OperationOutcome outcome = TeslaBLE::OperationOutcome::FAILED;
 
   vehicle_->send_command_result(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Phase Observed Poll",
@@ -1716,13 +1716,13 @@ TEST_F(VehicleTest, WrapperCanObservePhaseTransitions) {
         return client->build_car_server_get_vehicle_data_message(buff, len,
                                                                  CarServer_GetVehicleData_getChargeState_tag);
       },
-      [&](TeslaBLE::OperationResult result) { outcome = result.outcome(); }, TeslaBLE::WakePolicy::WakeIfNeeded,
+      [&](TeslaBLE::OperationResult result) { outcome = result.outcome(); }, TeslaBLE::WakePolicy::WAKE_IF_NEEDED,
       [&](TeslaBLE::OperationPhase phase) { phases.push_back(phase); });
 
   vehicle_->loop();
 
   ASSERT_GE(phases.size(), 1) << "Phase callback should fire at least once";
-  EXPECT_EQ(phases.front(), TeslaBLE::OperationPhase::Queued) << "First phase should be Queued";
+  EXPECT_EQ(phases.front(), TeslaBLE::OperationPhase::QUEUED) << "First phase should be Queued";
 
   auto writes = mock_ble_->get_written_data();
   ASSERT_GE(writes.size(), 1);
@@ -1735,12 +1735,12 @@ TEST_F(VehicleTest, WrapperCanObservePhaseTransitions) {
   vehicle_->loop();
 
   ASSERT_GE(phases.size(), 2) << "Should see Queued → EnsuringVcsecSession → EnsuringInfotainmentSession phases";
-  EXPECT_EQ(phases[1], TeslaBLE::OperationPhase::EnsuringVcsecSession);
+  EXPECT_EQ(phases[1], TeslaBLE::OperationPhase::ENSURING_VCSEC_SESSION);
 }
 
 TEST_F(VehicleTest, WrapperCompatibleSuccessPreservesExistingBoolSemantics) {
   vehicle_->set_connected(true);
-  vehicle_->set_sleep_state(TeslaBLE::SleepState::Asleep);
+  vehicle_->set_sleep_state(TeslaBLE::SleepState::ASLEEP);
 
   bool callback_called = false;
   bool callback_success = false;
@@ -1755,7 +1755,7 @@ TEST_F(VehicleTest, WrapperCompatibleSuccessPreservesExistingBoolSemantics) {
         callback_called = true;
         callback_success = success;
       },
-      TeslaBLE::WakePolicy::NoWakeSkip);
+      TeslaBLE::WakePolicy::NO_WAKE_SKIP);
 
   vehicle_->loop();
 
@@ -1774,16 +1774,16 @@ TEST(CommandStructTest, DefaultRequiresWakeIsTrue) {
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Test Command",
       [](Client *, uint8_t *, size_t *) { return TeslaBLE_Status_E_OK; }, nullptr);
 
-  ASSERT_EQ(cmd.wake_policy, TeslaBLE::WakePolicy::WakeIfNeeded)
+  ASSERT_EQ(cmd.wake_policy, TeslaBLE::WakePolicy::WAKE_IF_NEEDED)
       << "Commands should default to requiring wake for safety";
 }
 
 TEST(CommandStructTest, RequiresWakeCanBeSetFalse) {
   Command cmd(
       UniversalMessage_Domain_DOMAIN_INFOTAINMENT, "Test Poll",
-      [](Client *, uint8_t *, size_t *) { return TeslaBLE_Status_E_OK; }, nullptr, TeslaBLE::WakePolicy::NoWakeSkip);
+      [](Client *, uint8_t *, size_t *) { return TeslaBLE_Status_E_OK; }, nullptr, TeslaBLE::WakePolicy::NO_WAKE_SKIP);
 
-  ASSERT_EQ(cmd.wake_policy, TeslaBLE::WakePolicy::NoWakeSkip);
+  ASSERT_EQ(cmd.wake_policy, TeslaBLE::WakePolicy::NO_WAKE_SKIP);
 }
 
 // ============================================================================


### PR DESCRIPTION
- Rename enum constants to UPPER_CASE (SleepState, WakePolicy,
  OperationPhase, OperationOutcome, OperationTerminalReason)
- Use .at() instead of operator[] for bounds-safe container access
- Use designated initializers for pb_ostream_t
- Move BUILDERS map to function-local static to avoid throwing during
  static initialization
- Suppress modernize-avoid-variadic-functions on log_internal with
  format(printf) attribute for compile-time format safety
- Fix 15 pre-existing format string bugs exposed by the attribute:
  %ld for int32_t, %p without void* cast
