### PR TITLE
fix: resolve -Wformat and unused-function warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,17 @@ else()
     
     target_link_libraries(TeslaBLE PUBLIC mbedcrypto mbedtls mbedx509)
 
+    # Strict warnings for the library's own C++ sources. Scoped to this target and
+    # language so third-party deps (mbedtls, nanopb) and generated .pb.c files are
+    # unaffected. -Wno-format-nonliteral allows variadic log-forwarding helpers.
+    # Host ABIs still miss xtensa-only int32_t/long mismatches; use PRI macros
+    # from <cinttypes> for fixed-width values.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(TeslaBLE PRIVATE
+            $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wformat=2 -Wno-format-nonliteral -Werror>
+        )
+    endif()
+
     set_target_properties(TeslaBLE PROPERTIES PUBLIC_HEADER "${TESLABLE_PUBLIC_HEADERS}")
     
     # Only build tests if this is the main project

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -27,6 +27,7 @@
 #include <pb_encode.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -133,7 +134,7 @@ const Peer *Client::get_peer(UniversalMessage_Domain domain) const {
     case UniversalMessage_Domain_DOMAIN_INFOTAINMENT:
       return session_infotainment_.get();
     default:
-      LOG_ERROR("Invalid domain: %d", domain);
+      LOG_ERROR("Invalid domain: %d", static_cast<int>(domain));
       return nullptr;
   }
 }
@@ -182,8 +183,8 @@ int Client::build_white_list_message(Keys_Role role, VCSEC_KeyFormFactor form_fa
 
   // Validate role parameter - Tesla protocol requires specific role values
   if (role < _Keys_Role_MIN || role > _Keys_Role_MAX) {
-    LOG_ERROR("[build_white_list_message] Invalid role value: %d (valid range: %d-%d)", role, _Keys_Role_MIN,
-              _Keys_Role_MAX);
+    LOG_ERROR("[build_white_list_message] Invalid role value: %d (valid range: %d-%d)", static_cast<int>(role),
+              static_cast<int>(_Keys_Role_MIN), static_cast<int>(_Keys_Role_MAX));
     return TeslaBLE_Status_E_ERROR_INVALID_PARAMS;
   }
 
@@ -520,7 +521,7 @@ int Client::build_universal_message_with_payload(pb_byte_t *payload, size_t payl
                                                  UniversalMessage_Domain domain, pb_byte_t *output_buffer,
                                                  size_t *output_length, bool encrypt_payload) {
   LOG_DEBUG("[build_universal_message_with_payload] Called with payload=%p, payload_length=%zu, domain=%d", payload,
-            payload_length, domain);
+            payload_length, static_cast<int>(domain));
 
   // Reject empty or null payloads
   if (payload == nullptr || payload_length == 0) {
@@ -589,8 +590,6 @@ int Client::build_universal_message_with_payload(pb_byte_t *payload, size_t payl
     signature_data.signer_identity = signer_identity;
 
     // Set AES-GCM signature data
-    Signatures_AES_GCM_Personalized_Signature_Data aes_gcm_signature_data =
-        Signatures_AES_GCM_Personalized_Signature_Data_init_default;
     signature_data.which_sig_type = Signatures_SignatureData_AES_GCM_Personalized_data_tag;
     signature_data.sig_type.AES_GCM_Personalized_data.counter = session->get_counter();
     signature_data.sig_type.AES_GCM_Personalized_data.expires_at = expires_at;
@@ -816,7 +815,7 @@ int Client::build_car_server_vehicle_action_message(pb_byte_t *output_buffer, si
   const auto &builders = VehicleActionBuilder::get_builders();
   auto it = builders.find(which_vehicle_action);
   if (it == builders.end()) {
-    LOG_ERROR("Unsupported vehicle action type: %d", which_vehicle_action);
+    LOG_ERROR("Unsupported vehicle action type: %" PRId32, which_vehicle_action);
     return TeslaBLE_Status_E_ERROR_INVALID_PARAMS;
   }
 

--- a/src/crypto_context.cpp
+++ b/src/crypto_context.cpp
@@ -200,7 +200,8 @@ TeslaBLE_Status_E CryptoContext::generate_public_key(pb_byte_t *output_buffer, s
   }
 
   if (mbedtls_pk_get_type(private_key_context_.get()) != MBEDTLS_PK_ECKEY) {
-    LOG_ERROR("Private key is not an EC key, type: %d", mbedtls_pk_get_type(private_key_context_.get()));
+    LOG_ERROR("Private key is not an EC key, type: %d",
+              static_cast<int>(mbedtls_pk_get_type(private_key_context_.get())));
     return TeslaBLE_Status_E_ERROR_INTERNAL;
   }
 

--- a/src/message_builders.cpp
+++ b/src/message_builders.cpp
@@ -6,38 +6,9 @@
 #include "car_server.pb.h"
 #include "universal_message.pb.h"
 
-namespace TeslaBLE {
+#include <cinttypes>
 
-// Forward declarations of builder functions
-static int build_charging_set_limit(CarServer_VehicleAction &action, const void *data);
-static int build_charging_start_stop(CarServer_VehicleAction &action, const void *data);
-static int build_set_charging_amps(CarServer_VehicleAction &action, const void *data);
-static int build_charge_port_door_open(CarServer_VehicleAction &action, const void *data);
-static int build_charge_port_door_close(CarServer_VehicleAction &action, const void *data);
-static int build_scheduled_charging(CarServer_VehicleAction &action, const void *data);
-static int build_hvac_auto_action(CarServer_VehicleAction &action, const void *data);
-static int build_hvac_steering_wheel_heater(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_flash_lights(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_honk_horn(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_set_sentry_mode(CarServer_VehicleAction &action, const void *data);
-static int build_media_play_action(CarServer_VehicleAction &action, const void *data);
-static int build_media_next_favorite(CarServer_VehicleAction &action, const void *data);
-static int build_media_previous_favorite(CarServer_VehicleAction &action, const void *data);
-static int build_media_next_track(CarServer_VehicleAction &action, const void *data);
-static int build_media_previous_track(CarServer_VehicleAction &action, const void *data);
-static int build_ping_action(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_window_action(CarServer_VehicleAction &action, const void *data);
-static int build_hvac_set_preconditioning_max(CarServer_VehicleAction &action, const void *data);
-static int build_hvac_temperature_adjustment(CarServer_VehicleAction &action, const void *data);
-static int build_hvac_climate_keeper(CarServer_VehicleAction &action, const void *data);
-static int build_hvac_bioweapon_mode(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_schedule_software_update(CarServer_VehicleAction &action, const void *data);
-static int build_set_cabin_overheat_protection(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_cancel_software_update(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_reset_valet_pin(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_reset_pin_to_drive(CarServer_VehicleAction &action, const void *data);
-static int build_driving_clear_speed_limit_pin_admin(CarServer_VehicleAction &action, const void *data);
-static int build_vehicle_control_reset_pin_to_drive_admin(CarServer_VehicleAction &action, const void *data);
+namespace TeslaBLE {
 
 namespace {
 template<typename T> const T *require_data(const void *data, const char *message) {
@@ -95,7 +66,7 @@ int VehicleActionBuilder::build_charging_set_limit(CarServer_VehicleAction &acti
 
   int32_t percent = *percent_ptr;
   if (!ParameterValidator::is_valid_charging_limit(percent)) {
-    LOG_ERROR("Invalid charging limit percentage: %d (must be 50-100)", percent);
+    LOG_ERROR("Invalid charging limit percentage: %" PRId32 " (must be 50-100)", percent);
     return TeslaBLE_Status_E_ERROR_INVALID_PARAMS;
   }
 
@@ -133,9 +104,9 @@ int VehicleActionBuilder::build_set_charging_amps(CarServer_VehicleAction &actio
   }
 
   int32_t amps = *amps_ptr;
-  LOG_DEBUG("Charging amps received: %d", amps);
+  LOG_DEBUG("Charging amps received: %" PRId32, amps);
   if (!ParameterValidator::is_valid_charging_amps(amps)) {
-    LOG_ERROR("Invalid charging amps value: %d (must be 0-80)", amps);
+    LOG_ERROR("Invalid charging amps value: %" PRId32 " (must be 0-80)", amps);
     return TeslaBLE_Status_E_ERROR_INVALID_PARAMS;
   }
 

--- a/src/peer.cpp
+++ b/src/peer.cpp
@@ -202,11 +202,12 @@ int Peer::update_session(Signatures_SessionInfo *session_info) {
   bool time_advanced = (clock_time_ <= session_info->clock_time);
   bool should_update = epoch_changed || time_advanced;
 
-  LOG_DEBUG("Session update check: epoch_changed=%d, time_advanced=%d (local=%u, vehicle=%u)", epoch_changed,
-            time_advanced, clock_time_, session_info->clock_time);
+  LOG_DEBUG("Session update check: epoch_changed=%d, time_advanced=%d (local=%" PRIu32 ", vehicle=%" PRIu32 ")",
+            epoch_changed, time_advanced, clock_time_, session_info->clock_time);
 
   if (!epoch_changed && session_info->counter < counter_) {
-    LOG_WARNING("Session counter replay detected (vehicle=%u, local=%u)", session_info->counter, counter_);
+    LOG_WARNING("Session counter replay detected (vehicle=%" PRIu32 ", local=%" PRIu32 ")", session_info->counter,
+                counter_);
     return TeslaBLE_Status_E_ERROR_COUNTER_REPLAY;
   }
 
@@ -220,10 +221,10 @@ int Peer::update_session(Signatures_SessionInfo *session_info) {
   // ONLY update if vehicle counter is higher. This preserves anti-replay monotonicity
   // even across epoch changes, matching signer.go behavior.
   if (should_update && session_info->counter > counter_) {
-    LOG_INFO("Updating counter to %u (old_counter=%u)", session_info->counter, counter_);
+    LOG_INFO("Updating counter to %" PRIu32 " (old_counter=%" PRIu32 ")", session_info->counter, counter_);
     set_counter(session_info->counter);
   } else if (should_update) {
-    LOG_DEBUG("Keeping higher local counter %u (vehicle sent %u)", counter_, session_info->counter);
+    LOG_DEBUG("Keeping higher local counter %" PRIu32 " (vehicle sent %" PRIu32 ")", counter_, session_info->counter);
   }
 
   // Update epoch and time only when conditions are met
@@ -251,7 +252,7 @@ int Peer::update_session(Signatures_SessionInfo *session_info) {
     }
   }
 
-  LOG_DEBUG("Updated session: counter=%d, clock_time=%d", counter_, session_info->clock_time);
+  LOG_DEBUG("Updated session: counter=%" PRIu32 ", clock_time=%" PRIu32, counter_, session_info->clock_time);
 
   // Successful update clears error state and restores session validity
   // This matches Go's UpdateSessionInfo behavior where successful updates restore session
@@ -268,8 +269,8 @@ int Peer::force_update_session(Signatures_SessionInfo *session_info) {
     return TeslaBLE_Status_E_ERROR_INVALID_SESSION;
   }
 
-  LOG_WARNING("Force updating session (bypassing counter checks): vehicle=%u local=%u", session_info->counter,
-              counter_);
+  LOG_WARNING("Force updating session (bypassing counter checks): vehicle=%" PRIu32 " local=%" PRIu32 "",
+              session_info->counter, counter_);
 
   int status = set_epoch(session_info->epoch);
   if (status != TeslaBLE_Status_E_OK) {
@@ -293,7 +294,7 @@ int Peer::force_update_session(Signatures_SessionInfo *session_info) {
   is_valid_ = true;
   has_shared_secret_ = true;
 
-  LOG_INFO("Force updated session: counter=%u, clock_time=%u", counter_, clock_time_);
+  LOG_INFO("Force updated session: counter=%" PRIu32 ", clock_time=%" PRIu32, counter_, clock_time_);
   return TeslaBLE_Status_E_OK;
 }
 

--- a/src/tb_logging.cpp
+++ b/src/tb_logging.cpp
@@ -595,7 +595,7 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
   }
 
   if (charge_state.which_optional_battery_level) {
-    LOG_DEBUG("Battery Level: %d%%", charge_state.optional_battery_level.battery_level);
+    LOG_DEBUG("Battery Level: %" PRId32 "%%", charge_state.optional_battery_level.battery_level);
   }
 
   if (charge_state.which_optional_battery_range) {
@@ -603,39 +603,40 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
   }
 
   if (charge_state.which_optional_charger_power) {
-    LOG_DEBUG("Charger Power: %d", charge_state.optional_charger_power.charger_power);
+    LOG_DEBUG("Charger Power: %" PRId32, charge_state.optional_charger_power.charger_power);
   }
 
   if (charge_state.which_optional_charge_rate_mph) {
-    LOG_DEBUG("Charge Rate: %d mph", charge_state.optional_charge_rate_mph.charge_rate_mph);
+    LOG_DEBUG("Charge Rate: %" PRId32 " mph", charge_state.optional_charge_rate_mph.charge_rate_mph);
   }
 
   if (charge_state.which_optional_minutes_to_full_charge) {
-    LOG_DEBUG("Minutes to Full: %d", charge_state.optional_minutes_to_full_charge.minutes_to_full_charge);
+    LOG_DEBUG("Minutes to Full: %" PRId32, charge_state.optional_minutes_to_full_charge.minutes_to_full_charge);
   }
 
   if (charge_state.which_optional_minutes_to_charge_limit) {
-    LOG_DEBUG("Minutes to Charge Limit: %d", charge_state.optional_minutes_to_charge_limit.minutes_to_charge_limit);
+    LOG_DEBUG("Minutes to Charge Limit: %" PRId32,
+              charge_state.optional_minutes_to_charge_limit.minutes_to_charge_limit);
   }
 
   if (charge_state.which_optional_charger_voltage) {
-    LOG_DEBUG("Charger Voltage: %d", charge_state.optional_charger_voltage.charger_voltage);
+    LOG_DEBUG("Charger Voltage: %" PRId32, charge_state.optional_charger_voltage.charger_voltage);
   }
 
   if (charge_state.which_optional_charger_pilot_current) {
-    LOG_DEBUG("Charger Pilot Current: %d", charge_state.optional_charger_pilot_current.charger_pilot_current);
+    LOG_DEBUG("Charger Pilot Current: %" PRId32, charge_state.optional_charger_pilot_current.charger_pilot_current);
   }
 
   if (charge_state.which_optional_charger_actual_current) {
-    LOG_DEBUG("Charger Actual Current: %d", charge_state.optional_charger_actual_current.charger_actual_current);
+    LOG_DEBUG("Charger Actual Current: %" PRId32, charge_state.optional_charger_actual_current.charger_actual_current);
   }
 
   if (charge_state.which_optional_charge_current_request) {
-    LOG_DEBUG("Charge Current Request: %d", charge_state.optional_charge_current_request.charge_current_request);
+    LOG_DEBUG("Charge Current Request: %" PRId32, charge_state.optional_charge_current_request.charge_current_request);
   }
 
   if (charge_state.which_optional_charge_current_request_max) {
-    LOG_DEBUG("Charge Current Request Max: %d",
+    LOG_DEBUG("Charge Current Request Max: %" PRId32,
               charge_state.optional_charge_current_request_max.charge_current_request_max);
   }
 
@@ -665,15 +666,16 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
   }
 
   if (charge_state.which_optional_charger_phases) {
-    LOG_DEBUG("Charger Phases: %d", charge_state.optional_charger_phases.charger_phases);
+    LOG_DEBUG("Charger Phases: %" PRId32, charge_state.optional_charger_phases.charger_phases);
   }
 
   if (charge_state.which_optional_charge_port_color) {
-    LOG_DEBUG("Charge Port Color: %d", charge_state.optional_charge_port_color.charge_port_color);
+    LOG_DEBUG("Charge Port Color: %d", static_cast<int>(charge_state.optional_charge_port_color.charge_port_color));
   }
 
   if (charge_state.which_optional_charge_limit_reason) {
-    LOG_DEBUG("Charge Limit Reason: %d", charge_state.optional_charge_limit_reason.charge_limit_reason);
+    LOG_DEBUG("Charge Limit Reason: %d",
+              static_cast<int>(charge_state.optional_charge_limit_reason.charge_limit_reason));
   }
 
   if (charge_state.has_managed_charging_state) {
@@ -682,17 +684,17 @@ void log_charge_state(const char *tag, const CarServer_ChargeState &charge_state
       LOG_DEBUG("Charge On Solar State: %d", charge_state.managed_charging_state.charge_on_solar_state.which_state);
     }
     if (charge_state.managed_charging_state.which_optional_minutes_to_lower_limit) {
-      LOG_DEBUG("Managed Charging Minutes to Lower Limit: %d",
+      LOG_DEBUG("Managed Charging Minutes to Lower Limit: %" PRId32,
                 charge_state.managed_charging_state.optional_minutes_to_lower_limit.minutes_to_lower_limit);
     }
   }
 
   if (charge_state.which_optional_outlet_state) {
-    LOG_DEBUG("Outlet State: %d", charge_state.optional_outlet_state.outlet_state);
+    LOG_DEBUG("Outlet State: %d", static_cast<int>(charge_state.optional_outlet_state.outlet_state));
   }
 
   if (charge_state.which_optional_power_feed_state) {
-    LOG_DEBUG("Power Feed State: %d", charge_state.optional_power_feed_state.power_feed_state);
+    LOG_DEBUG("Power Feed State: %d", static_cast<int>(charge_state.optional_power_feed_state.power_feed_state));
   }
 }
 
@@ -754,7 +756,7 @@ void log_carserver_response(const char *tag, const CarServer_Response *msg) {
           LOG_DEBUG("    Speed: %.1f", msg->response_msg.vehicleData.drive_state.optional_speed_float.speed_float);
         }
         if (msg->response_msg.vehicleData.drive_state.which_optional_power) {
-          LOG_DEBUG("    Power: %d", msg->response_msg.vehicleData.drive_state.optional_power.power);
+          LOG_DEBUG("    Power: %" PRId32, msg->response_msg.vehicleData.drive_state.optional_power.power);
         }
       }
 
@@ -796,7 +798,7 @@ void log_carserver_response(const char *tag, const CarServer_Response *msg) {
       break;
     case CarServer_Response_ping_tag:
       LOG_DEBUG("  ping:");
-      LOG_DEBUG("    ping: %d", msg->response_msg.ping.ping_id);
+      LOG_DEBUG("    ping: %" PRId32, msg->response_msg.ping.ping_id);
       break;
     default:
       // do nothing

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -722,7 +722,7 @@ void TeslaBLE::Vehicle::handle_message_(const UniversalMessage_RoutableMessage &
         handle_carserver_message_(msg);
         break;
       default:
-        LOG_DEBUG("Message from unknown domain: %d", msg.from_destination.sub_destination.domain);
+        LOG_DEBUG("Message from unknown domain: %d", static_cast<int>(msg.from_destination.sub_destination.domain));
         break;
     }
   }
@@ -784,7 +784,8 @@ void TeslaBLE::Vehicle::handle_session_info_message_(const UniversalMessage_Rout
   log_session_info(TESLA_LOG_TAG, &session_info);
 
   if (session_info.status != Signatures_Session_Info_Status_SESSION_INFO_STATUS_OK) {
-    LOG_WARNING("Session info status not OK for %s: %d", domain_to_string(domain), session_info.status);
+    LOG_WARNING("Session info status not OK for %s: %d", domain_to_string(domain),
+                static_cast<int>(session_info.status));
     auto cmd = peek_command_();
     if (cmd) {
       mark_command_failed_(
@@ -927,7 +928,7 @@ void TeslaBLE::Vehicle::handle_carserver_message_(const UniversalMessage_Routabl
   log_carserver_response(TESLA_LOG_TAG, &response);
   auto *peer = client_->get_peer(UniversalMessage_Domain_DOMAIN_INFOTAINMENT);
   if (peer && response_counter > 0 && !peer->validate_response_counter(response_counter)) {
-    LOG_WARNING("Duplicate response counter detected: %u", response_counter);
+    LOG_WARNING("Duplicate response counter detected: %" PRIu32, response_counter);
   }
   if (response.which_response_msg == CarServer_Response_vehicleData_tag) {
     auto &vd = response.response_msg.vehicleData;
@@ -1114,7 +1115,8 @@ void TeslaBLE::Vehicle::load_session_from_storage_(UniversalMessage_Domain domai
 
   // Validate session status
   if (session_info.status != Signatures_Session_Info_Status_SESSION_INFO_STATUS_OK) {
-    LOG_WARNING("Stored session for %s has invalid status: %d", domain_to_string(domain), session_info.status);
+    LOG_WARNING("Stored session for %s has invalid status: %d", domain_to_string(domain),
+                static_cast<int>(session_info.status));
     return;
   }
 
@@ -1133,19 +1135,21 @@ void TeslaBLE::Vehicle::load_session_from_storage_(UniversalMessage_Domain domai
 
   // Reject sessions older than 1 hour (3600 seconds)
   if (session_age_seconds > 3600) {
-    LOG_WARNING("Stored session for %s is too old (%u seconds) - rejecting to prevent crypto errors",
+    LOG_WARNING("Stored session for %s is too old (%" PRIu32 " seconds) - rejecting to prevent crypto errors",
                 domain_to_string(domain), session_age_seconds);
     return;
   }
 
-  LOG_DEBUG("Session age validation passed for %s: %u seconds old", domain_to_string(domain), session_age_seconds);
+  LOG_DEBUG("Session age validation passed for %s: %" PRIu32 " seconds old", domain_to_string(domain),
+            session_age_seconds);
 
   // Update the peer with the loaded session
   auto *peer = client_->get_peer(domain);
   if (peer) {
     // Use update_session - it will handle counter correctly (preserve higher value)
     if (peer->update_session(&session_info) == 0) {
-      LOG_INFO("Loaded session from storage for %s (counter: %u)", domain_to_string(domain), session_info.counter);
+      LOG_INFO("Loaded session from storage for %s (counter: %" PRIu32 ")", domain_to_string(domain),
+               session_info.counter);
     } else {
       LOG_ERROR("Failed to apply stored session for %s", domain_to_string(domain));
     }


### PR DESCRIPTION
## Summary
No functional changes - warnings cleanup only.

- Remove 29 dead file-scope static forward declarations in `src/message_builders.cpp` (unqualified names in `get_builders()` resolve to the class members; GCC flagged 27 as `-Wunused-function`)
- Replace bare `%d`/`%u` with `<cinttypes>` PRI macros for all `int32_t`/`uint32_t` args across `message_builders.cpp`, `tb_logging.cpp`, `peer.cpp`, `client.cpp`, `vehicle.cpp` (xtensa `int32_t` = `long int`)
- Explicit `static_cast<int>` for enums passed to `%d` (`domain`, `role`, session status, charge-state enums, mbedtls key type)
- Remove dead local `aes_gcm_signature_data` in `client.cpp`
- Standalone CMake build now compiles TeslaBLE's own C++ sources with `-Wall -Wformat=2 -Wno-format-nonliteral -Werror` (target/language-scoped; deps and generated `.pb.c` unaffected), so this warning class fails CI on host compilers

## Verification
- Local build + all 233 tests green under the new strict flags
- `clang-format --check` and `clang-tidy --check` pass
- Cross-toolchain check via esphome-tesla-ble: zero warnings from `managed_components/tesla-ble/` on both riscv32 (`m5stack-nanoc6`) and xtensa (`m5stack-atoms3`) ESP-IDF builds