### PR TITLE
chore: sync mbedtls to 3.6.6-idf for ESP-IDF 5.5.x

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -85,7 +85,7 @@ jobs:
         if: matrix.check != 'format'
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
-          key: checks-${{ matrix.check }}-${{ runner.os }}-mbedtls-3.6.5
+          key: checks-${{ matrix.check }}-${{ runner.os }}-mbedtls-3.6.6
 
       - name: Set reusable strings
         if: matrix.check != 'format'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ else()
     FetchContent_Declare(
         mbedtls
         GIT_REPOSITORY https://github.com/espressif/mbedtls.git
-        GIT_TAG mbedtls-3.6.5-idf
+        GIT_TAG mbedtls-3.6.6-idf
         GIT_SHALLOW TRUE
     )
     FetchContent_MakeAvailable(nanopb mbedtls)


### PR DESCRIPTION
## Summary
Maintenance sweep against ESPHome 2026.8.1 / ESP-IDF v5.5.5:

- Standalone-build mbedtls pin: `mbedtls-3.6.5-idf` → `mbedtls-3.6.6-idf` (IDF v5.5.5 vendors espressif/mbedtls from the `mbedtls-3.6.6-idf` line)
- Bump CI ccache key accordingly
- Stays on mbedtls 3.6.x per ESP-IDF stable docs; IDF 6.x (mbedtls 4.x/PSA) is out of scope

Note: this pin only affects the standalone/host build path (tests, CI); ESP-IDF builds use the IDF-provided mbedtls.

Also checked during sweep:
- nanopb: 0.4.9.1 is still the latest release - no bump available
- vehicle-command protocol docs updates (FLAG_ENCRYPT_RESPONSE example fix): implementation already adheres, verified TLV-by-TLV - no changes needed

## Verification
- Fresh configure + full build with `mbedtls-3.6.6-idf` (resolves to 3d49d990) and all 233 tests pass under `-Werror` flags