### PR TITLE
fix: accept stored sessions whose clock_time is ahead of the local clock

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1133,7 +1133,7 @@ void TeslaBLE::Vehicle::load_session_from_storage_(UniversalMessage_Domain domai
   // Stale sessions cause crypto failures when vehicle's internal state changes
   uint32_t current_time = static_cast<uint32_t>(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
   uint32_t session_time = session_info.clock_time;
-  uint32_t session_age_seconds = current_time - session_time;
+  int64_t session_age_seconds = static_cast<int64_t>(current_time) - static_cast<int64_t>(session_time);
 
   // If session has no clock_time, check if it's from a previous run (be very conservative)
   if (session_time == 0) {
@@ -1142,15 +1142,19 @@ void TeslaBLE::Vehicle::load_session_from_storage_(UniversalMessage_Domain domai
     return;
   }
 
-  // Reject sessions older than 1 hour (3600 seconds)
-  if (session_age_seconds > 3600) {
-    LOG_WARNING("Stored session for %s is too old (%" PRIu32 " seconds) - rejecting to prevent crypto errors",
-                domain_to_string(domain), session_age_seconds);
+  // The local clock can sit behind the recorded session time after a reboot
+  // before the time source resyncs. That says nothing about staleness, so
+  // accept instead of letting unsigned subtraction underflow to a huge age.
+  if (session_age_seconds < 0) {
+    LOG_DEBUG("Session time for %s is ahead of the local clock - accepting", domain_to_string(domain));
+  } else if (session_age_seconds > 3600) {
+    LOG_WARNING("Stored session for %s is too old (%lld seconds) - rejecting to prevent crypto errors",
+                domain_to_string(domain), static_cast<long long>(session_age_seconds));
     return;
+  } else {
+    LOG_DEBUG("Session age validation passed for %s: %lld seconds old", domain_to_string(domain),
+              static_cast<long long>(session_age_seconds));
   }
-
-  LOG_DEBUG("Session age validation passed for %s: %" PRIu32 " seconds old", domain_to_string(domain),
-            session_age_seconds);
 
   // Update the peer with the loaded session
   auto *peer = client_->get_peer(domain);

--- a/tests/test_vehicle.cpp
+++ b/tests/test_vehicle.cpp
@@ -719,6 +719,61 @@ TEST_F(VehicleTest, CounterReplaySessionInfoIsAppliedInsteadOfRejected) {
       << "Verified lower-counter session info should be applied and persisted";
 }
 
+namespace {
+std::vector<std::string> g_session_load_logs;
+void session_load_log_sink(TeslaBLE::LogLevel, const char *, int, const char *format, va_list args) {
+  char buffer[512];
+  vsnprintf(buffer, sizeof(buffer), format, args);
+  g_session_load_logs.emplace_back(buffer);
+}
+}  // namespace
+
+TEST_F(VehicleTest, StoredSessionWithFutureClockTimeIsNotRejected) {
+  // A device that reboots before its time source resyncs (e.g. HA-pushed
+  // time) runs with the system clock far behind the clock_time recorded in
+  // the stored session. Unsigned subtraction used to underflow there,
+  // rejecting EVERY stored session as "too old" until time synced again.
+  namespace sc = std::chrono;
+
+  Signatures_SessionInfo session_info = Signatures_SessionInfo_init_default;
+  session_info.status = Signatures_Session_Info_Status_SESSION_INFO_STATUS_OK;
+  session_info.clock_time = static_cast<uint32_t>(
+      sc::duration_cast<sc::seconds>(sc::system_clock::now().time_since_epoch()).count() + 1000000);
+  session_info.counter = 7;
+  std::memcpy(session_info.epoch, TeslaBLE::TestConstants::TEST_EPOCH, sizeof(session_info.epoch));
+  std::memcpy(session_info.publicKey.bytes, TeslaBLE::TestConstants::EXPECTED_VEHICLE_PUBLIC_KEY, 65);
+  session_info.publicKey.size = 65;
+
+  pb_byte_t blob[256];
+  size_t blob_length = sizeof(blob);
+  ASSERT_EQ(TeslaBLE::pb_encode_fields(blob, &blob_length, Signatures_SessionInfo_fields, &session_info),
+            TeslaBLE_Status_E_OK);
+  mock_storage_->set_data("session_vcsec", std::vector<uint8_t>(blob, blob + blob_length));
+
+  g_session_load_logs.clear();
+  TeslaBLE::set_log_callback(session_load_log_sink);
+
+  {
+    auto vehicle_with_stored_session = std::make_shared<Vehicle>(mock_ble_, mock_storage_);
+    (void) vehicle_with_stored_session;
+  }
+
+  TeslaBLE::set_log_callback(nullptr);
+
+  bool loaded = false;
+  bool rejected_as_too_old = false;
+  for (const auto &m : g_session_load_logs) {
+    if (m.find("Loaded session from storage") != std::string::npos) {
+      loaded = true;
+    }
+    if (m.find("is too old") != std::string::npos) {
+      rejected_as_too_old = true;
+    }
+  }
+  EXPECT_TRUE(loaded) << "Stored session should load when the local clock is behind session time";
+  EXPECT_FALSE(rejected_as_too_old) << "Backwards clock must not read as an ancient session";
+}
+
 TEST_F(VehicleTest, InfotainmentActionFailureSurfacesPlainTextReason) {
   vehicle_->set_connected(true);
   vehicle_->set_sleep_state(TeslaBLE::SleepState::AWAKE);


### PR DESCRIPTION
## Problem
The session-age gate computed `current_time - session_time` as **unsigned**: after a reboot before the time source resyncs (this repo pushes time via `platform: homeassistant` only), the local clock sits far behind `clock_time` recorded in stored sessions. The subtraction underflows to ~4 billion seconds, so every stored session was rejected as "too old" until time synced - disabling persistence exactly when connectivity is also degraded, and forcing a full handshake on every boot.

## Evidence
- Repro test (red before fix): `VehicleTest.StoredSessionWithFutureClockTimeIsNotRejected` preloads a correctly-encoded session whose `clock_time` is 1e6 s in the future; before the fix the load logs "is too old" and the session is dropped.
- Config: packages/common.yml uses `time: platform: homeassistant` with no SNTP fallback, so this state is reachable in normal HA-restart scenarios.

## Fix
Compute the age as signed (`int64_t`): negative age (clock behind session time) logs and accepts; the existing >3600s staleness rejection is unchanged.

## Verification
- New test red -> green; full suite 235/235 pass; clang-format + clang-tidy clean.